### PR TITLE
Add basic trainer pages and navigation

### DIFF
--- a/frontend/src/assets/styles/pages/_auto-mode.scss
+++ b/frontend/src/assets/styles/pages/_auto-mode.scss
@@ -1,0 +1,9 @@
+.auto-mode {
+    &__title {
+        margin-bottom: 1rem;
+    }
+
+    &__subtitle {
+        color: #666;
+    }
+}

--- a/frontend/src/assets/styles/pages/_index.scss
+++ b/frontend/src/assets/styles/pages/_index.scss
@@ -1,2 +1,6 @@
 @forward "home";
 @forward "about";
+@forward "program-management";
+@forward "trainee-screens";
+@forward "auto-mode";
+@forward "training-window";

--- a/frontend/src/assets/styles/pages/_program-management.scss
+++ b/frontend/src/assets/styles/pages/_program-management.scss
@@ -1,0 +1,9 @@
+.program-management {
+    &__title {
+        margin-bottom: 1rem;
+    }
+
+    &__subtitle {
+        color: #666;
+    }
+}

--- a/frontend/src/assets/styles/pages/_trainee-screens.scss
+++ b/frontend/src/assets/styles/pages/_trainee-screens.scss
@@ -1,0 +1,9 @@
+.trainee-screens {
+    &__title {
+        margin-bottom: 1rem;
+    }
+
+    &__subtitle {
+        color: #666;
+    }
+}

--- a/frontend/src/assets/styles/pages/_training-window.scss
+++ b/frontend/src/assets/styles/pages/_training-window.scss
@@ -1,0 +1,9 @@
+.training-window {
+    &__title {
+        margin-bottom: 1rem;
+    }
+
+    &__subtitle {
+        color: #666;
+    }
+}

--- a/frontend/src/components/layout/TraineeAttendance.tsx
+++ b/frontend/src/components/layout/TraineeAttendance.tsx
@@ -1,8 +1,10 @@
-import React from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faUser, faClock } from "@fortawesome/free-solid-svg-icons";
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faUser, faClock } from '@fortawesome/free-solid-svg-icons';
+import { useNavigate } from 'react-router-dom';
 
 function TraineeAttendance() {
+    const navigate = useNavigate();
     return (
         <div className="trainee-attendance">
             <div className="trainee-attendance__details">
@@ -21,7 +23,10 @@ function TraineeAttendance() {
                     </div>
                 </div>
             </div>
-            <button className="trainee-attendance__action">
+            <button
+                className="trainee-attendance__action"
+                onClick={() => navigate('/training')}
+            >
                 <span className="trainee-attendance__action-text">פתח מסך אימון</span>
             </button>
         </div>

--- a/frontend/src/components/pages/TraineesPage.tsx
+++ b/frontend/src/components/pages/TraineesPage.tsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-function TraineesPage() {
-    return (
-        <div>TraineesPage</div>
-    )
-}
-
-export default TraineesPage

--- a/frontend/src/components/ui/ProgressBar.tsx
+++ b/frontend/src/components/ui/ProgressBar.tsx
@@ -13,7 +13,9 @@ export interface ProgressBarProps {
     animated?: boolean;       // animate stripes
     ariaLabel?: string;       // a11y label
     className?: string;       // extra className
-    style?: React.CSSProperties;
+    style?: React.CSSProperties & {
+        '--progress-value'?: string;
+    };
 }
 
 export default function ProgressBar({
@@ -50,7 +52,7 @@ export default function ProgressBar({
             aria-valuemin={0}
             aria-valuemax={safeMax}
             aria-valuenow={Math.round((pct * safeMax) / 100)}
-            style={{ ...style, ["--progress-value" as any]: `${pct}%` }}
+            style={{ ...style, '--progress-value': `${pct}%` }}
         >
             <div className="progress__bar">
                 {showLabel && (

--- a/frontend/src/pages/AutoMode.tsx
+++ b/frontend/src/pages/AutoMode.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function AutoMode() {
+    return (
+        <div className="auto-mode container">
+            <h1 className="auto-mode__title">מצב הפעלה אוטומטית</h1>
+            <p className="auto-mode__subtitle">
+                מחזוריות אוטומטית בין כל המתאמנים
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,16 +1,36 @@
 import TraineeAttendance from '@components/layout/TraineeAttendance';
 import { faCalendar, faGear, faPlay, faTv } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useEffect, useState } from "react";
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default function Home() {
-    const [currentTime, setCurrentTime] = useState("");
+    const navigate = useNavigate();
+    const [currentTime, setCurrentTime] = useState('');
 
     const userOptions = [
-        { title: "מסכי מתאמנים", subtitle: "הצגת כל המתאמנים בתצוגה אחידה", icon: faTv, action: () => console.log("Settings clicked"), iconColor: "#007bff" },
-        { title: "מצב הפעלה אוטומטית", subtitle: "מחזוריות אוטומטית בין כל המתאמנים", icon: faPlay, action: () => console.log("Settings clicked"), iconColor: "#9238d5" },
-        { title: "ניהול תוכניות", subtitle: "עריכת תוכניות אימונים ולוחות זמנים", icon: faGear, action: () => console.log("Settings clicked"), iconColor: "#1d9e59" },
-    ]
+        {
+            title: 'מסכי מתאמנים',
+            subtitle: 'הצגת כל המתאמנים בתצוגה אחידה',
+            icon: faTv,
+            action: () => navigate('/trainees'),
+            iconColor: '#007bff',
+        },
+        {
+            title: 'מצב הפעלה אוטומטית',
+            subtitle: 'מחזוריות אוטומטית בין כל המתאמנים',
+            icon: faPlay,
+            action: () => navigate('/auto-mode'),
+            iconColor: '#9238d5',
+        },
+        {
+            title: 'ניהול תוכניות',
+            subtitle: 'עריכת תוכניות אימונים ולוחות זמנים',
+            icon: faGear,
+            action: () => navigate('/programs'),
+            iconColor: '#1d9e59',
+        },
+    ];
 
     useEffect(() => {
         const updateClock = () => {

--- a/frontend/src/pages/ProgramManagement.tsx
+++ b/frontend/src/pages/ProgramManagement.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function ProgramManagement() {
+    return (
+        <div className="program-management container">
+            <h1 className="program-management__title">ניהול תוכניות</h1>
+            <p className="program-management__subtitle">
+                יצירת ועריכת תוכניות אימון מותאמות אישית
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/pages/TraineeScreens.tsx
+++ b/frontend/src/pages/TraineeScreens.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function TraineeScreens() {
+    return (
+        <div className="trainee-screens container">
+            <h1 className="trainee-screens__title">מסכי מתאמנים</h1>
+            <p className="trainee-screens__subtitle">
+                הצגת כל המתאמנים לשעה הנוכחית
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/pages/TrainingWindow.tsx
+++ b/frontend/src/pages/TrainingWindow.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function TrainingWindow() {
+    return (
+        <div className="training-window container">
+            <h1 className="training-window__title">מסך אימון</h1>
+            <p className="training-window__subtitle">בחר מתאמן כדי להתחיל אימון</p>
+        </div>
+    );
+}

--- a/frontend/src/routes/routes.tsx
+++ b/frontend/src/routes/routes.tsx
@@ -1,10 +1,18 @@
 import About from '../pages/About';
 import Home from '../pages/Home';
+import ProgramManagement from '../pages/ProgramManagement';
+import TraineeScreens from '../pages/TraineeScreens';
+import AutoMode from '../pages/AutoMode';
+import TrainingWindow from '../pages/TrainingWindow';
 import type { RouteObject } from 'react-router-dom';
 
 const routes: RouteObject[] = [
     { path: '/', element: <Home /> },
     { path: '/about', element: <About /> },
+    { path: '/programs', element: <ProgramManagement /> },
+    { path: '/trainees', element: <TraineeScreens /> },
+    { path: '/auto-mode', element: <AutoMode /> },
+    { path: '/training', element: <TrainingWindow /> },
 ];
 
 export default routes;


### PR DESCRIPTION
## Summary
- Add core pages (program management, trainee screens, auto mode, training window)
- Hook up navigation from dashboard and trainee attendance
- Include SCSS partials for new pages and fix ProgressBar type

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9ba7925b48332a748a1146ff85d36