### PR TITLE
fix: handle programs missing exercises

### DIFF
--- a/frontend/src/pages/ProgramEdit.tsx
+++ b/frontend/src/pages/ProgramEdit.tsx
@@ -33,7 +33,12 @@ export default function ProgramEdit() {
                 const programs: Program[] = JSON.parse(stored);
                 const existing = programs.find((p) => p.id === Number(id));
                 if (existing) {
-                    setProgram(existing);
+                    setProgram({
+                        ...existing,
+                        exercises: existing.exercises ?? [
+                            { name: '', sets: '', weight: '', rest: '' },
+                        ],
+                    });
                 }
             }
         }
@@ -86,7 +91,7 @@ export default function ProgramEdit() {
                     />
                 </label>
 
-                {program.exercises.map((exercise, idx) => (
+                {(program.exercises || []).map((exercise, idx) => (
                     <div key={idx} className="program-edit__exercise">
                         <label className="program-edit__field">
                             <span className="program-edit__label">שם התרגיל</span>


### PR DESCRIPTION
## Summary
- default loaded program to have exercises array
- guard exercises mapping to prevent crash

## Testing
- `cd frontend && npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `cd ../backend && npm test` *(fails: Cannot find module './items.service' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d82fd870833288e846b5ae975207