### PR TITLE
Connect frontend store with backend and add exercise sync

### DIFF
--- a/backend/src/modules/exercises/exercises.controller.ts
+++ b/backend/src/modules/exercises/exercises.controller.ts
@@ -34,4 +34,9 @@ export class ExercisesController {
   remove(@Param('id', ParseIntPipe) id: number) {
     return this.svc.remove(id);
   }
+
+  @Post('sync')
+  sync() {
+    return this.svc.syncFromWger();
+  }
 }

--- a/backend/src/modules/exercises/exercises.service.ts
+++ b/backend/src/modules/exercises/exercises.service.ts
@@ -33,4 +33,21 @@ export class ExercisesService {
   remove(id: number) {
     return this.repo.delete(id);
   }
+
+  async syncFromWger() {
+    const resp = await fetch('https://wger.de/api/v2/exercise/?language=2&status=2&limit=500');
+    const data = await resp.json();
+    for (const item of data.results ?? []) {
+      const existing = await this.repo.findOne({ where: { name: item.name } });
+      if (!existing) {
+        const exercise = this.repo.create({
+          name: item.name,
+          category: 'accessory',
+          description: item.description,
+        });
+        await this.repo.save(exercise);
+      }
+    }
+    return this.findAll();
+  }
 }

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Base URL for backend API
+VITE_API_URL=http://localhost:4000

--- a/frontend/src/pages/TraineeScreens.tsx
+++ b/frontend/src/pages/TraineeScreens.tsx
@@ -1,5 +1,5 @@
 import { useGetTraineesQuery, useLogTrainingMutation } from '@store/slices/api/apiSlice';
-import { useAppDispatch, addLog } from '@store';
+import { useAppDispatch, addLog, setTrainees } from '@store';
 import type { Trainee } from '@store/slices/api/Trainee';
 import TrainingMonitorCube from '@components/layout/TrainingMonitorCube';
 import { useEffect } from 'react';
@@ -46,6 +46,10 @@ export default function TraineeScreens() {
     useEffect(() => {
         localStorage.setItem('programs', JSON.stringify(localPrograms));
     }, []);
+
+    useEffect(() => {
+        dispatch(setTrainees(trainees));
+    }, [trainees, dispatch]);
 
     const useLocal = (!trainees || trainees.length === 0) && localPrograms.length > 0;
 

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -7,6 +7,7 @@ import type { TypedUseSelectorHook } from 'react-redux';
 import countReducer from './slices/count/countSlice';
 import { api } from './slices/api/apiSlice';
 import trainingLogsReducer from './slices/trainingLogs/trainingLogsSlice';
+import traineesReducer from './slices/trainees/traineesSlice';
 // import userReducer from './slices/user/userSlice';
 
 export const store = configureStore({
@@ -14,6 +15,7 @@ export const store = configureStore({
         [api.reducerPath]: api.reducer,
         count: countReducer,
         trainingLogs: trainingLogsReducer,
+        trainees: traineesReducer,
         // user: userReducer,
     },
     middleware: (getDefault) =>
@@ -32,3 +34,4 @@ export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 export * from './slices/count/countSlice';
 export * from './slices/user/userSlice';
 export * from './slices/trainingLogs/trainingLogsSlice';
+export * from './slices/trainees/traineesSlice';

--- a/frontend/src/store/slices/api/Exercise.ts
+++ b/frontend/src/store/slices/api/Exercise.ts
@@ -1,0 +1,8 @@
+export interface Exercise {
+  id: number;
+  name: string;
+  category: string;
+  equipment?: string;
+  description?: string;
+  scalingOptions?: string[];
+}

--- a/frontend/src/store/slices/api/apiSlice.ts
+++ b/frontend/src/store/slices/api/apiSlice.ts
@@ -2,6 +2,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import type { Post } from './Post';
 import type { Trainee } from './Trainee';
 import type { TrainingLog } from './TrainingLog';
+import type { Exercise } from './Exercise';
 
 // 1️⃣ Define your “base” config
 export const api = createApi({
@@ -15,7 +16,7 @@ export const api = createApi({
             return headers;
         },
     }),
-    tagTypes: ['Post', 'Trainee', 'TrainingLog'],                         // for cache invalidation
+    tagTypes: ['Post', 'Trainee', 'TrainingLog', 'Exercise'],                         // for cache invalidation
     endpoints: (build) => ({
         getPosts: build.query<Post[], void>({
             query: () => '/posts',
@@ -68,6 +69,20 @@ export const api = createApi({
             query: (body) => ({ url: '/training-logs', method: 'POST', body }),
             invalidatesTags: [{ type: 'TrainingLog', id: 'LIST' }],
         }),
+        getExercises: build.query<Exercise[], void>({
+            query: () => '/exercises',
+            providesTags: (result) =>
+                result
+                    ? [
+                          ...result.map(({ id }) => ({ type: 'Exercise' as const, id })),
+                          { type: 'Exercise', id: 'LIST' },
+                      ]
+                    : [{ type: 'Exercise', id: 'LIST' }],
+        }),
+        syncExercises: build.mutation<Exercise[], void>({
+            query: () => ({ url: '/exercises/sync', method: 'POST' }),
+            invalidatesTags: [{ type: 'Exercise', id: 'LIST' }],
+        }),
     }),
 });
 
@@ -78,4 +93,6 @@ export const {
     useSyncTraineesMutation,
     useAssignProgramMutation,
     useLogTrainingMutation,
+    useGetExercisesQuery,
+    useSyncExercisesMutation,
 } = api;

--- a/frontend/src/store/slices/trainees/traineesSlice.ts
+++ b/frontend/src/store/slices/trainees/traineesSlice.ts
@@ -1,0 +1,26 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { Trainee } from '../api/Trainee';
+
+interface TraineesState {
+  list: Trainee[];
+}
+
+const initialState: TraineesState = {
+  list: [],
+};
+
+const traineesSlice = createSlice({
+  name: 'trainees',
+  initialState,
+  reducers: {
+    setTrainees(state, action: PayloadAction<Trainee[]>) {
+      state.list = action.payload;
+    },
+    addTrainee(state, action: PayloadAction<Trainee>) {
+      state.list.push(action.payload);
+    },
+  },
+});
+
+export const { setTrainees, addTrainee } = traineesSlice.actions;
+export default traineesSlice.reducer;


### PR DESCRIPTION
## Summary
- add exercises sync endpoint sourcing data from wger API
- expose exercises queries/mutations in frontend API slice
- create trainees slice to store trainee list and update TraineeScreens
- document backend API base URL in `.env.example`

## Testing
- `npm test` *(fails: Cannot find module './items.service')*
- `npm run lint` *(fails: 161 problems (146 errors, 15 warnings))*
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a9fb87f09883328c5ceafcee2782c7