### PR TITLE
Sync trainees from Boostapp on page load

### DIFF
--- a/frontend/src/pages/TraineeScreens.tsx
+++ b/frontend/src/pages/TraineeScreens.tsx
@@ -1,4 +1,8 @@
-import { useGetTraineesQuery, useLogTrainingMutation } from '@store/slices/api/apiSlice';
+import {
+    useGetTraineesQuery,
+    useLogTrainingMutation,
+    useSyncTraineesMutation,
+} from '@store/slices/api/apiSlice';
 import { useAppDispatch, addLog, setTrainees } from '@store';
 import type { Trainee } from '@store/slices/api/Trainee';
 import TrainingMonitorCube from '@components/layout/TrainingMonitorCube';
@@ -41,11 +45,13 @@ const localPrograms: LocalProgram[] = [
 export default function TraineeScreens() {
     const { data: trainees = [] } = useGetTraineesQuery();
     const [logTraining] = useLogTrainingMutation();
+    const [syncTrainees] = useSyncTraineesMutation();
     const dispatch = useAppDispatch();
 
     useEffect(() => {
         localStorage.setItem('programs', JSON.stringify(localPrograms));
-    }, []);
+        syncTrainees();
+    }, [syncTrainees]);
 
     useEffect(() => {
         dispatch(setTrainees(trainees));


### PR DESCRIPTION
## Summary
- attempt Boostapp API sync with fallback HTML scraping
- sync trainees automatically when the trainee screens page mounts

## Testing
- `npm test` (backend) *(fails: Cannot find module 'src/modules/users/users.service' and other missing dependencies)*
- `npx eslint "{src,apps,libs,test}/**/*.ts"` *(fails: many lint errors)*
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint` (frontend) *(fails: TraineeScreens defined but never used in Home.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fec5e2fc8332ad90d2db99d82bd1