### PR TITLE
feat: add global styles and searchable select

### DIFF
--- a/frontend/src/assets/styles/abstracts/_variables.scss
+++ b/frontend/src/assets/styles/abstracts/_variables.scss
@@ -33,9 +33,17 @@ $radius: 12px;
     --color-card: #f5f5f5;
     --color-text: #333333;
     --color-accent: #4f46e5;
+    --color-success: #4caf50;
+    --color-error: #f44336;
+    --color-warning: #ff9800;
+    --color-border: #cccccc;
 }
 
 $color-bg: var(--color-bg);
 $color-card: var(--color-card);
 $color-text: var(--color-text);
 $color-accent: var(--color-accent);
+$color-success: var(--color-success);
+$color-error: var(--color-error);
+$color-warning: var(--color-warning);
+$color-border: var(--color-border);

--- a/frontend/src/assets/styles/components/_SearchableSelect.scss
+++ b/frontend/src/assets/styles/components/_SearchableSelect.scss
@@ -1,0 +1,34 @@
+@use '../abstracts' as *;
+
+.searchable-select {
+    position: relative;
+
+    &__input {
+        width: 100%;
+    }
+
+    &__list {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        z-index: 10;
+        background: $color-card;
+        border: 1px solid $color-border;
+        border-radius: $radius;
+        max-height: 200px;
+        overflow-y: auto;
+        margin-top: $space-unit / 2;
+        list-style: none;
+        padding: 0;
+    }
+
+    &__option {
+        padding: $space-unit * 1.5;
+        cursor: pointer;
+
+        &:hover {
+            background: $color-bg;
+        }
+    }
+}

--- a/frontend/src/assets/styles/components/_TrainingProgramModal.scss
+++ b/frontend/src/assets/styles/components/_TrainingProgramModal.scss
@@ -1,3 +1,5 @@
+@use '../abstracts' as *;
+
 .training-program-modal {
     position: fixed;
     top: 0;
@@ -31,7 +33,7 @@
 
 .training-program-modal__input {
     padding: 0.5rem;
-    border: 1px solid #ccc;
+    border: 1px solid $color-border;
     border-radius: 4px;
 }
 

--- a/frontend/src/assets/styles/components/_button.scss
+++ b/frontend/src/assets/styles/components/_button.scss
@@ -1,0 +1,24 @@
+@use '../abstracts' as *;
+
+button {
+    padding: $space-unit * 1.5 $space-unit * 2;
+    border: none;
+    border-radius: $radius;
+    cursor: pointer;
+    background: $color-accent;
+    color: #fff;
+    transition: background 0.2s ease;
+
+    &.btn--success {
+        background: $color-success;
+    }
+
+    &.btn--error {
+        background: $color-error;
+    }
+
+    &.btn--warning {
+        background: $color-warning;
+        color: #000;
+    }
+}

--- a/frontend/src/assets/styles/components/_index.scss
+++ b/frontend/src/assets/styles/components/_index.scss
@@ -1,6 +1,8 @@
 @forward "button";
+@forward "input";
 @forward "ExerciseList";
 @forward "TrainingMonitorCube";
 @forward "ProgressBar";
 @forward "TraineeAttencance";
 @forward "TrainingProgramModal";
+@forward "SearchableSelect";

--- a/frontend/src/assets/styles/components/_input.scss
+++ b/frontend/src/assets/styles/components/_input.scss
@@ -1,0 +1,17 @@
+@use '../abstracts' as *;
+
+input {
+    padding: $space-unit * 1.5;
+    border: 1px solid $color-border;
+    border-radius: $radius;
+    font-size: $base-font;
+    box-sizing: border-box;
+
+    &.input--success {
+        border-color: $color-success;
+    }
+
+    &.input--error {
+        border-color: $color-error;
+    }
+}

--- a/frontend/src/assets/styles/pages/_program-edit.scss
+++ b/frontend/src/assets/styles/pages/_program-edit.scss
@@ -1,3 +1,5 @@
+@use '../abstracts' as *;
+
 .program-edit {
     &__form {
         display: flex;
@@ -14,12 +16,12 @@
 
     &__input {
         padding: 0.5rem;
-        border: 1px solid #ccc;
+        border: 1px solid $color-border;
         border-radius: 4px;
     }
 
     &__exercise {
-        border: 1px solid #eee;
+        border: 1px solid $color-border;
         border-radius: 8px;
         padding: 1rem;
         display: grid;
@@ -30,8 +32,8 @@
     &__delete-exercise {
         grid-column: 1 / -1;
         justify-self: start;
-        background: #f8d7da;
-        color: #721c24;
+        background: $color-error;
+        color: #fff;
         border: none;
         border-radius: 4px;
         padding: 0.25rem 0.5rem;
@@ -45,7 +47,7 @@
         gap: 0.25rem;
         padding: 0.5rem 1rem;
         border: none;
-        background: #007bff;
+        background: $color-accent;
         color: #fff;
         border-radius: 6px;
         cursor: pointer;
@@ -61,8 +63,8 @@
     &__cancel {
         padding: 0.5rem 1rem;
         border: none;
-        background: #ccc;
-        color: #000;
+        background: $color-warning;
+        color: $color-text;
         border-radius: 6px;
         cursor: pointer;
     }
@@ -70,7 +72,7 @@
     &__save {
         padding: 0.5rem 1rem;
         border: none;
-        background: #1d9e59;
+        background: $color-success;
         color: #fff;
         border-radius: 6px;
         cursor: pointer;

--- a/frontend/src/components/ExerciseSelector.tsx
+++ b/frontend/src/components/ExerciseSelector.tsx
@@ -1,4 +1,5 @@
 import { exercises } from '../data/exercises';
+import SearchableSelect from './ui/SearchableSelect';
 
 interface Props {
     value: string;
@@ -7,18 +8,11 @@ interface Props {
 
 export default function ExerciseSelector({ value, onChange }: Props) {
     return (
-        <div className="exercise-selector">
-            <input
-                list="exercise-options"
-                className="program-edit__input"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-            />
-            <datalist id="exercise-options">
-                {exercises.map((ex) => (
-                    <option key={ex} value={ex} />
-                ))}
-            </datalist>
-        </div>
+        <SearchableSelect
+            options={exercises}
+            value={value}
+            onChange={onChange}
+            inputClassName="program-edit__input"
+        />
     );
 }

--- a/frontend/src/components/TrainingProgramModal.tsx
+++ b/frontend/src/components/TrainingProgramModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import SearchableSelect from './ui/SearchableSelect';
 
 interface Program {
     id: number;
@@ -28,30 +29,25 @@ export default function TrainingProgramModal({ isOpen, onClose }: Props) {
         <div className="training-program-modal">
             <div className="training-program-modal__header">
                 <h2>תוכניות אימון</h2>
-                <button onClick={onClose}>סגור</button>
+                <button className="btn btn--error" onClick={onClose}>סגור</button>
             </div>
             <div className="training-program-modal__controls">
-                <button className="training-program-modal__reschedule">העבר תור</button>
-                <input
-                    className="training-program-modal__input"
-                    list="training-options"
+                <button className="btn btn--warning training-program-modal__reschedule">העבר תור</button>
+                <SearchableSelect
+                    options={trainingOptions}
                     value={selection}
-                    onChange={(e) => setSelection(e.target.value)}
+                    onChange={setSelection}
                     placeholder="בחר סוג אימון"
+                    inputClassName="training-program-modal__input"
                 />
-                <datalist id="training-options">
-                    {trainingOptions.map((opt) => (
-                        <option key={opt} value={opt} />
-                    ))}
-                </datalist>
             </div>
             <ul className="training-program-modal__list">
                 {programs.map((p) => (
                     <li key={p.id} className="training-program-modal__item">
                         <span>{p.name}</span>
                         <div className="training-program-modal__item-actions">
-                            <button>בחר</button>
-                            <button>העבר זמן</button>
+                            <button className="btn btn--success">בחר</button>
+                            <button className="btn btn--warning">העבר זמן</button>
                         </div>
                     </li>
                 ))}

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,7 +1,7 @@
 export function Footer() {
     return (
         <footer className="container" style={{ textAlign: 'center', marginTop: '2rem' }}>
-            © 2025 Your Name
+            © 2025 Gym Trainer
         </footer>
     );
 }

--- a/frontend/src/components/ui/SearchableSelect.tsx
+++ b/frontend/src/components/ui/SearchableSelect.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+
+interface Props {
+    options: string[];
+    value: string;
+    onChange: (val: string) => void;
+    placeholder?: string;
+    inputClassName?: string;
+}
+
+export default function SearchableSelect({ options, value, onChange, placeholder, inputClassName }: Props) {
+    const [open, setOpen] = useState(false);
+    const filtered = options.filter((opt) => opt.toLowerCase().includes(value.toLowerCase()));
+
+    const handleSelect = (opt: string) => {
+        onChange(opt);
+        setOpen(false);
+    };
+
+    return (
+        <div className="searchable-select">
+            <input
+                className={`searchable-select__input ${inputClassName ?? ''}`.trim()}
+                value={value}
+                placeholder={placeholder}
+                onChange={(e) => onChange(e.target.value)}
+                onFocus={() => setOpen(true)}
+                onBlur={() => {
+                    setTimeout(() => setOpen(false), 100);
+                }}
+            />
+            {open && filtered.length > 0 && (
+                <ul className="searchable-select__list">
+                    {filtered.map((opt) => (
+                        <li
+                            key={opt}
+                            className="searchable-select__option"
+                            onMouseDown={() => handleSelect(opt)}
+                        >
+                            {opt}
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- define shared color palette and base button/input styles
- replace datalists with searchable select component
- update footer branding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: TS6133: 'React' is declared but its value is never read, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68aa13520f848332859e1cdbef5596a5