### PR TITLE
Cache Wger exercise data locally

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { SessionsModule } from './modules/sessions/sessions.module';
 import { TrainingProgramsModule } from './modules/training-programs/training-programs.module';
 import { TraineesModule } from './modules/trainees/trainees.module';
 import { TrainingLogsModule } from './modules/training-logs/training-logs.module';
+import { ExercisesModule } from './modules/exercises/exercises.module';
 
 @Module({
 	imports: [
@@ -20,6 +21,7 @@ import { TrainingLogsModule } from './modules/training-logs/training-logs.module
                 TrainingProgramsModule,
                 TraineesModule,
                 TrainingLogsModule,
+                ExercisesModule,
         ],
 	controllers: [],
 	providers: [],

--- a/backend/src/database/db-init.service.ts
+++ b/backend/src/database/db-init.service.ts
@@ -131,6 +131,7 @@ export class DbInitService implements OnModuleInit {
         id SERIAL PRIMARY KEY,
         wger_id INTEGER UNIQUE NOT NULL,
         name VARCHAR(100),
+        is_front BOOLEAN DEFAULT false,
         created_at TIMESTAMP DEFAULT now(),
         updated_at TIMESTAMP DEFAULT now()
       );
@@ -151,6 +152,33 @@ export class DbInitService implements OnModuleInit {
         name VARCHAR(200),
         description TEXT,
         category_id INTEGER REFERENCES exercise_categories(id),
+        created_at TIMESTAMP DEFAULT now(),
+        updated_at TIMESTAMP DEFAULT now()
+      );
+    `,
+                exercise_translations: `
+      CREATE TABLE exercise_translations (
+        id SERIAL PRIMARY KEY,
+        exercise_id INTEGER REFERENCES exercises(id) ON DELETE CASCADE,
+        language INTEGER NOT NULL,
+        name VARCHAR(200) NOT NULL,
+        description TEXT
+      );
+      CREATE INDEX idx_exercise_translations_ex ON exercise_translations(exercise_id);
+    `,
+                exercise_info: `
+      CREATE TABLE exercise_info (
+        id SERIAL PRIMARY KEY,
+        wger_id INTEGER UNIQUE NOT NULL,
+        info JSONB
+      );
+    `,
+                exercise_videos: `
+      CREATE TABLE exercise_videos (
+        id SERIAL PRIMARY KEY,
+        wger_id INTEGER UNIQUE NOT NULL,
+        exercise_id INTEGER REFERENCES exercises(id) ON DELETE CASCADE,
+        url TEXT NOT NULL,
         created_at TIMESTAMP DEFAULT now(),
         updated_at TIMESTAMP DEFAULT now()
       );
@@ -206,12 +234,15 @@ export class DbInitService implements OnModuleInit {
 		{ tbl_name: 'exercise_categories', dependencies: [] },
 		{ tbl_name: 'muscles', dependencies: [] },
 		{ tbl_name: 'equipment', dependencies: [] },
-		{ tbl_name: 'exercises', dependencies: ['exercise_categories'] },
-		{ tbl_name: 'exercise_muscles', dependencies: ['exercises', 'muscles'] },
-		{ tbl_name: 'exercise_equipment', dependencies: ['exercises', 'equipment'] },
-		{ tbl_name: 'workout_types', dependencies: [] },
-		{ tbl_name: 'training_programs', dependencies: [] },
-	];
+                { tbl_name: 'exercises', dependencies: ['exercise_categories'] },
+                { tbl_name: 'exercise_translations', dependencies: ['exercises'] },
+                { tbl_name: 'exercise_info', dependencies: [] },
+                { tbl_name: 'exercise_videos', dependencies: ['exercises'] },
+                { tbl_name: 'exercise_muscles', dependencies: ['exercises', 'muscles'] },
+                { tbl_name: 'exercise_equipment', dependencies: ['exercises', 'equipment'] },
+                { tbl_name: 'workout_types', dependencies: [] },
+                { tbl_name: 'training_programs', dependencies: [] },
+        ];
 
 	constructor(private dataSource: DataSource) { }
 

--- a/backend/src/modules/exercises/dto/create-exercise.dto.ts
+++ b/backend/src/modules/exercises/dto/create-exercise.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsOptional, IsString, IsArray } from 'class-validator';
+import { IsEnum, IsOptional, IsString, IsArray, IsNumber } from 'class-validator';
 import { ExerciseCategory } from '../entities/exercise.entity';
 
 export class CreateExerciseDto {
@@ -7,6 +7,9 @@ export class CreateExerciseDto {
 
     @IsEnum(['cardio', 'strength', 'olympic', 'gymnastics', 'accessory'])
     category: ExerciseCategory;
+
+    @IsOptional() @IsNumber()
+    wgerId?: number;
 
     @IsOptional() @IsString()
     equipment?: string;

--- a/backend/src/modules/exercises/entities/exercise-info.entity.ts
+++ b/backend/src/modules/exercises/entities/exercise-info.entity.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class ExerciseInfo {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ unique: true })
+    wgerId: number;
+
+    @Column({ type: 'jsonb' })
+    info: any;
+}

--- a/backend/src/modules/exercises/entities/exercise-translation.entity.ts
+++ b/backend/src/modules/exercises/entities/exercise-translation.entity.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Exercise } from './exercise.entity';
+
+@Entity()
+export class ExerciseTranslation {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => Exercise, (e) => e.translations, { onDelete: 'CASCADE' })
+    exercise: Exercise;
+
+    @Column()
+    language: number;
+
+    @Column({ length: 200 })
+    name: string;
+
+    @Column({ type: 'text', nullable: true })
+    description?: string;
+}

--- a/backend/src/modules/exercises/entities/exercise-video.entity.ts
+++ b/backend/src/modules/exercises/entities/exercise-video.entity.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Exercise } from './exercise.entity';
+
+@Entity()
+export class ExerciseVideo {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ unique: true })
+    wgerId: number;
+
+    @ManyToOne(() => Exercise, (e) => e.videos, { onDelete: 'CASCADE' })
+    exercise: Exercise;
+
+    @Column({ type: 'text' })
+    url: string;
+}

--- a/backend/src/modules/exercises/entities/exercise.entity.ts
+++ b/backend/src/modules/exercises/entities/exercise.entity.ts
@@ -1,4 +1,6 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { ExerciseTranslation } from './exercise-translation.entity';
+import { ExerciseVideo } from './exercise-video.entity';
 
 export type ExerciseCategory =
     | 'cardio'
@@ -11,6 +13,9 @@ export type ExerciseCategory =
 export class Exercise {
     @PrimaryGeneratedColumn()
     id: number;
+
+    @Column({ unique: true, nullable: true })
+    wgerId?: number;
 
     @Column({ type: 'varchar', length: 200 })
     name: string;
@@ -27,4 +32,10 @@ export class Exercise {
     // stores as comma‑separated in a single text column
     @Column({ type: 'simple-array', nullable: true })
     scalingOptions?: string[];
+
+    @OneToMany(() => ExerciseTranslation, (t) => t.exercise)
+    translations?: ExerciseTranslation[];
+
+    @OneToMany(() => ExerciseVideo, (v) => v.exercise)
+    videos?: ExerciseVideo[];
 }

--- a/backend/src/modules/exercises/entities/muscle.entity.ts
+++ b/backend/src/modules/exercises/entities/muscle.entity.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Muscle {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ unique: true })
+    wgerId: number;
+
+    @Column({ length: 100 })
+    name: string;
+
+    @Column({ default: false })
+    isFront: boolean;
+}

--- a/backend/src/modules/exercises/exercises.module.ts
+++ b/backend/src/modules/exercises/exercises.module.ts
@@ -1,8 +1,17 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ExercisesService } from './exercises.service';
 import { ExercisesController } from './exercises.controller';
+import { Exercise } from './entities/exercise.entity';
+import { ExerciseTranslation } from './entities/exercise-translation.entity';
+import { ExerciseInfo } from './entities/exercise-info.entity';
+import { ExerciseVideo } from './entities/exercise-video.entity';
+import { Muscle } from './entities/muscle.entity';
 
 @Module({
+  imports: [
+    TypeOrmModule.forFeature([Exercise, ExerciseTranslation, ExerciseInfo, ExerciseVideo, Muscle]),
+  ],
   controllers: [ExercisesController],
   providers: [ExercisesService],
 })

--- a/backend/src/modules/exercises/exercises.service.spec.ts
+++ b/backend/src/modules/exercises/exercises.service.spec.ts
@@ -2,6 +2,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ExercisesService } from './exercises.service';
 import { Exercise } from './entities/exercise.entity';
+import { ExerciseTranslation } from './entities/exercise-translation.entity';
+import { ExerciseInfo } from './entities/exercise-info.entity';
+import { ExerciseVideo } from './entities/exercise-video.entity';
+import { Muscle } from './entities/muscle.entity';
 
 describe('ExercisesService', () => {
   let service: ExercisesService;
@@ -11,6 +15,10 @@ describe('ExercisesService', () => {
       providers: [
         ExercisesService,
         { provide: getRepositoryToken(Exercise), useValue: {} },
+        { provide: getRepositoryToken(ExerciseTranslation), useValue: {} },
+        { provide: getRepositoryToken(ExerciseInfo), useValue: {} },
+        { provide: getRepositoryToken(ExerciseVideo), useValue: {} },
+        { provide: getRepositoryToken(Muscle), useValue: {} },
       ],
     }).compile();
 

--- a/backend/src/modules/exercises/exercises.service.ts
+++ b/backend/src/modules/exercises/exercises.service.ts
@@ -2,6 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Exercise } from './entities/exercise.entity';
+import { ExerciseTranslation } from './entities/exercise-translation.entity';
+import { ExerciseInfo } from './entities/exercise-info.entity';
+import { ExerciseVideo } from './entities/exercise-video.entity';
+import { Muscle } from './entities/muscle.entity';
 import { CreateExerciseDto } from './dto/create-exercise.dto';
 import { UpdateExerciseDto } from './dto/update-exercise.dto';
 
@@ -9,45 +13,124 @@ import { UpdateExerciseDto } from './dto/update-exercise.dto';
 export class ExercisesService {
   constructor(
     @InjectRepository(Exercise)
-    private readonly repo: Repository<Exercise>,
+    private readonly exerciseRepo: Repository<Exercise>,
+    @InjectRepository(ExerciseTranslation)
+    private readonly translationRepo: Repository<ExerciseTranslation>,
+    @InjectRepository(ExerciseInfo)
+    private readonly infoRepo: Repository<ExerciseInfo>,
+    @InjectRepository(ExerciseVideo)
+    private readonly videoRepo: Repository<ExerciseVideo>,
+    @InjectRepository(Muscle)
+    private readonly muscleRepo: Repository<Muscle>,
   ) { }
 
   create(dto: CreateExerciseDto) {
-    const e = this.repo.create(dto);
-    return this.repo.save(e);
+    const e = this.exerciseRepo.create(dto);
+    return this.exerciseRepo.save(e);
   }
 
   findAll() {
-    return this.repo.find();
+    return this.exerciseRepo.find({ relations: ['translations', 'videos'] });
   }
 
   findOne(id: number) {
-    return this.repo.findOneOrFail({ where: { id } });
+    return this.exerciseRepo.findOneOrFail({ where: { id }, relations: ['translations', 'videos'] });
   }
 
   async update(id: number, dto: UpdateExerciseDto) {
-    await this.repo.update(id, dto);
+    await this.exerciseRepo.update(id, dto);
     return this.findOne(id);
   }
 
   remove(id: number) {
-    return this.repo.delete(id);
+    return this.exerciseRepo.delete(id);
   }
 
   async syncFromWger() {
-    const resp = await fetch('https://wger.de/api/v2/exercise/?language=2&status=2&limit=500');
-    const data = await resp.json();
-    for (const item of data.results ?? []) {
-      const existing = await this.repo.findOne({ where: { name: item.name } });
-      if (!existing) {
-        const exercise = this.repo.create({
+    const [exRes, trRes, infoRes, vidRes, muscleRes] = await Promise.all([
+      fetch('https://wger.de/api/v2/exercise/?language=21&limit=2000'),
+      fetch('https://wger.de/api/v2/exercise-translation/?limit=2000'),
+      fetch('https://wger.de/api/v2/exerciseinfo/?limit=2000'),
+      fetch('https://wger.de/api/v2/video/?limit=2000'),
+      fetch('https://wger.de/api/v2/muscle/?limit=2000'),
+    ]);
+
+    const [exData, trData, infoData, vidData, muscleData] = await Promise.all([
+      exRes.json(),
+      trRes.json(),
+      infoRes.json(),
+      vidRes.json(),
+      muscleRes.json(),
+    ]);
+
+    for (const item of exData.results ?? []) {
+      let exercise = await this.exerciseRepo.findOne({ where: { wgerId: item.id } });
+      if (!exercise) {
+        exercise = this.exerciseRepo.create({
+          wgerId: item.id,
           name: item.name,
           category: 'accessory',
           description: item.description,
         });
-        await this.repo.save(exercise);
+      } else {
+        exercise.name = item.name;
+        exercise.description = item.description;
       }
+      await this.exerciseRepo.save(exercise);
     }
+
+    for (const t of trData.results ?? []) {
+      const exercise = await this.exerciseRepo.findOne({ where: { wgerId: t.exercise } });
+      if (!exercise) continue;
+      let translation = await this.translationRepo.findOne({ where: { exercise: { id: exercise.id }, language: t.language } });
+      if (!translation) {
+        translation = this.translationRepo.create({
+          exercise,
+          language: t.language,
+          name: t.name,
+          description: t.description,
+        });
+      } else {
+        translation.name = t.name;
+        translation.description = t.description;
+      }
+      await this.translationRepo.save(translation);
+    }
+
+    for (const m of muscleData.results ?? []) {
+      let muscle = await this.muscleRepo.findOne({ where: { wgerId: m.id } });
+      if (!muscle) {
+        muscle = this.muscleRepo.create({ wgerId: m.id, name: m.name, isFront: m.is_front });
+      } else {
+        muscle.name = m.name;
+        muscle.isFront = m.is_front;
+      }
+      await this.muscleRepo.save(muscle);
+    }
+
+    for (const info of infoData.results ?? []) {
+      let rec = await this.infoRepo.findOne({ where: { wgerId: info.id } });
+      if (!rec) {
+        rec = this.infoRepo.create({ wgerId: info.id, info });
+      } else {
+        rec.info = info;
+      }
+      await this.infoRepo.save(rec);
+    }
+
+    for (const v of vidData.results ?? []) {
+      const exercise = await this.exerciseRepo.findOne({ where: { wgerId: v.exercise } });
+      if (!exercise) continue;
+      let video = await this.videoRepo.findOne({ where: { wgerId: v.id } });
+      if (!video) {
+        video = this.videoRepo.create({ wgerId: v.id, url: v.video, exercise });
+      } else {
+        video.url = v.video;
+        video.exercise = exercise;
+      }
+      await this.videoRepo.save(video);
+    }
+
     return this.findAll();
   }
 }


### PR DESCRIPTION
## Summary
- Add persistent Wger exercise cache with translations, videos, and info
- Sync exercises, translations, muscles, videos, and info from Wger API at `/exercises/sync`
- Initialize database tables for new exercise-related data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa1b9c46a083328e6496704803e589