### PR TITLE
Fix exercise loading and persistence

### DIFF
--- a/frontend/src/assets/styles/pages/_program-edit.scss
+++ b/frontend/src/assets/styles/pages/_program-edit.scss
@@ -63,8 +63,8 @@
     &__cancel {
         padding: 0.5rem 1rem;
         border: none;
-        background: $color-warning;
-        color: $color-text;
+        background: $color-error;
+        color: #fff;
         border-radius: 6px;
         cursor: pointer;
     }

--- a/frontend/src/components/ExerciseSelector.tsx
+++ b/frontend/src/components/ExerciseSelector.tsx
@@ -6,7 +6,7 @@ interface Props {
     onChange: (val: string) => void;
 }
 
-const sanitize = (v: string) => v.replace(/<[^>]*>?/gm, '').trim();
+const sanitize = (v?: string | null) => (v ?? '').replace(/<[^>]*>?/gm, '').trim();
 
 export default function ExerciseSelector({ value, onChange }: Props) {
     const [options, setOptions] = useState<string[]>([]);
@@ -14,11 +14,11 @@ export default function ExerciseSelector({ value, onChange }: Props) {
     useEffect(() => {
         const fetchExercises = async () => {
             try {
-                const res = await fetch(
-                    'https://wger.de/api/v2/exercise/?language=21&limit=2000'
-                );
+                const res = await fetch('/api/exercises');
                 const data = await res.json();
-                const names = (data.results || []).map((e: any) => sanitize(e.name));
+                const names = (data || [])
+                    .map((e: any) => sanitize(e.name))
+                    .filter(Boolean);
                 setOptions(names);
             } catch (err) {
                 console.error('Failed to load exercises', err);


### PR DESCRIPTION
## Summary
- handle undefined names when sanitizing exercises
- style cancel buttons red and load exercise options from backend
- auto-sync exercises from WGER API into database when empty

## Testing
- `npm test` *(frontend - missing script)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa1dd72d6c8332bc57982064ee8997