### PR TITLE
fix: allow nullable email

### DIFF
--- a/backend/src/modules/users/entities/user.entity.ts
+++ b/backend/src/modules/users/entities/user.entity.ts
@@ -24,8 +24,8 @@ export class User {
     @Column({ length: 100, nullable: true })
     last_name?: string;
 
-    @Column({ length: 255, unique: true })
-    email: string;
+    @Column({ length: 255, unique: true, nullable: true })
+    email?: string;
 
     @Column({ length: 20, nullable: true })
     phone_num?: string;


### PR DESCRIPTION
## Summary
- allow email field to be nullable in User entity to prevent sync errors

## Testing
- `npm test`
- `npx eslint "{src,apps,libs,test}/**/*.ts"` *(fails: Replace `↹↹↹` with `······` ...)*

------
https://chatgpt.com/codex/tasks/task_e_68aa28ffde3c8332bbbd639bfaf92371