### PR TITLE
Use fallback translation names when syncing exercises

### DIFF
--- a/backend/src/modules/exercises/exercises.service.ts
+++ b/backend/src/modules/exercises/exercises.service.ts
@@ -88,12 +88,12 @@ export class ExercisesService implements OnModuleInit {
       if (!exercise) {
         exercise = this.exerciseRepo.create({
           wgerId: item.id,
-          name: item.name,
+          name,
           category: 'accessory',
           description: item.description,
         });
       } else {
-        exercise.name = item.name;
+        exercise.name = name;
         exercise.description = item.description;
       }
       await this.exerciseRepo.save(exercise);


### PR DESCRIPTION
## Summary
- Use translation name as fallback when WGER exercise lacks a name to avoid null constraint violation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa2c3b68148332abb1e6415118cfba