### PR TITLE
Handle invalid exercise API responses

### DIFF
--- a/frontend/src/components/ExerciseSelector.tsx
+++ b/frontend/src/components/ExerciseSelector.tsx
@@ -15,9 +15,16 @@ export default function ExerciseSelector({ value, onChange }: Props) {
         const fetchExercises = async () => {
             try {
                 const res = await fetch('/api/exercises');
-                const data = await res.json();
+                if (!res.ok) {
+                    throw new Error(`unexpected status ${res.status}`);
+                }
+                const contentType = res.headers.get('content-type') ?? '';
+                if (!contentType.includes('application/json')) {
+                    throw new Error(`expected JSON, got ${contentType}`);
+                }
+                const data: Array<{ name?: string }> = await res.json();
                 const names = (data || [])
-                    .map((e: any) => sanitize(e.name))
+                    .map((e) => sanitize(e.name))
                     .filter(Boolean);
                 setOptions(names);
             } catch (err) {


### PR DESCRIPTION
## Summary
- Validate `fetch` responses in `ExerciseSelector` before parsing JSON
- Type the exercise data to avoid `any`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa2d5172d08332b82257f2a530eaa3