### PR TITLE
fix: use API base URL for fetch requests

### DIFF
--- a/frontend/src/components/ExerciseSelector.tsx
+++ b/frontend/src/components/ExerciseSelector.tsx
@@ -14,7 +14,8 @@ export default function ExerciseSelector({ value, onChange }: Props) {
     useEffect(() => {
         const fetchExercises = async () => {
             try {
-                const res = await fetch('/api/exercises');
+                const apiUrl = import.meta.env.VITE_API_URL;
+                const res = await fetch(`${apiUrl}/exercises`);
                 if (!res.ok) {
                     throw new Error(`unexpected status ${res.status}`);
                 }

--- a/frontend/src/services/trainingPrograms.ts
+++ b/frontend/src/services/trainingPrograms.ts
@@ -23,7 +23,8 @@ export async function createProgram(program: Program) {
             rest: sanitize(e.rest),
         })),
     };
-    const res = await fetch('/api/training-programs', {
+    const apiUrl = import.meta.env.VITE_API_URL;
+    const res = await fetch(`${apiUrl}/training-programs`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(sanitized),


### PR DESCRIPTION
## Summary
- fetch exercises from configured backend URL
- use same base URL when creating training programs

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68aa2e0fdf9c83328637cd1e0cc31518