### PR TITLE
fix: allow exercise fetch when content-type is misreported

### DIFF
--- a/frontend/src/components/ExerciseSelector.tsx
+++ b/frontend/src/components/ExerciseSelector.tsx
@@ -19,10 +19,6 @@ export default function ExerciseSelector({ value, onChange }: Props) {
                 if (!res.ok) {
                     throw new Error(`unexpected status ${res.status}`);
                 }
-                const contentType = res.headers.get('content-type') ?? '';
-                if (!contentType.includes('application/json')) {
-                    throw new Error(`expected JSON, got ${contentType}`);
-                }
                 const data: Array<{ name?: string }> = await res.json();
                 const names = (data || [])
                     .map((e) => sanitize(e.name))


### PR DESCRIPTION
## Summary
- load exercises even if server sends a non-JSON content-type

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa301664c483328f0bfa20a9de750b