### PR TITLE
Aggregate exercise data and allow spaces in search

### DIFF
--- a/backend/src/database/db-init.service.ts
+++ b/backend/src/database/db-init.service.ts
@@ -158,6 +158,7 @@ export class DbInitService implements OnModuleInit {
     exercise_translations: `
       CREATE TABLE exercise_translations (
         id SERIAL PRIMARY KEY,
+        wger_id INTEGER UNIQUE NOT NULL,
         exercise_id INTEGER REFERENCES exercises(id) ON DELETE CASCADE,
         language INTEGER NOT NULL,
         name VARCHAR(200) NOT NULL,

--- a/backend/src/modules/exercises/entities/exercise-translation.entity.ts
+++ b/backend/src/modules/exercises/entities/exercise-translation.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, Index } from 'typeorm';
 import { Exercise } from './exercise.entity';
 
 @Entity()
@@ -6,9 +6,14 @@ export class ExerciseTranslation {
     @PrimaryGeneratedColumn()
     id: number;
 
+    @Index('idx_translation_wger_id')
+    @Column({ unique: true })
+    wgerId: number;
+
     @ManyToOne(() => Exercise, (e) => e.translations, { onDelete: 'CASCADE' })
     exercise: Exercise;
 
+    @Index('idx_translation_language')
     @Column()
     language: number;
 

--- a/backend/src/modules/exercises/entities/exercise-video.entity.ts
+++ b/backend/src/modules/exercises/entities/exercise-video.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, Index } from 'typeorm';
 import { Exercise } from './exercise.entity';
 
 @Entity()
@@ -6,6 +6,7 @@ export class ExerciseVideo {
     @PrimaryGeneratedColumn()
     id: number;
 
+    @Index('idx_video_wger_id')
     @Column({ unique: true })
     wgerId: number;
 

--- a/backend/src/modules/exercises/entities/exercise.entity.ts
+++ b/backend/src/modules/exercises/entities/exercise.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany, Index } from 'typeorm';
 import { ExerciseTranslation } from './exercise-translation.entity';
 import { ExerciseVideo } from './exercise-video.entity';
 
@@ -14,6 +14,7 @@ export class Exercise {
     @PrimaryGeneratedColumn()
     id: number;
 
+    @Index('idx_exercise_wger_id')
     @Column({ unique: true, nullable: true })
     wgerId?: number;
 

--- a/frontend/src/components/ExerciseSelector.tsx
+++ b/frontend/src/components/ExerciseSelector.tsx
@@ -6,7 +6,7 @@ interface Props {
     onChange: (val: string) => void;
 }
 
-const sanitize = (v?: string | null) => (v ?? '').replace(/<[^>]*>?/gm, '').trim();
+const sanitize = (v?: string | null) => (v ?? '').replace(/<[^>]*>?/gm, '');
 
 export default function ExerciseSelector({ value, onChange }: Props) {
     const [options, setOptions] = useState<string[]>([]);

--- a/frontend/src/pages/ProgramEdit.tsx
+++ b/frontend/src/pages/ProgramEdit.tsx
@@ -16,7 +16,7 @@ interface LocalProgram extends Program {
     id?: number;
 }
 
-const sanitize = (v: string) => v.replace(/<[^>]*>?/gm, '').trim();
+const sanitize = (v: string) => v.replace(/<[^>]*>?/gm, '');
 
 export default function ProgramEdit() {
     const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- index Wger IDs and language codes for exercises, translations, and videos
- fetch exercises with joined translations (languages 21 or 2) and videos
- keep spaces in Program Edit search inputs

## Testing
- `cd backend && npm test`
- `cd backend && npm run lint` *(fails: unsafe assignments and unused vars)*
- `cd frontend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa3414b580833291111053588b4311