### PR TITLE
Allow nullable wgerId in exercise translations

### DIFF
--- a/backend/src/modules/exercises/entities/exercise-translation.entity.ts
+++ b/backend/src/modules/exercises/entities/exercise-translation.entity.ts
@@ -7,7 +7,7 @@ export class ExerciseTranslation {
     id: number;
 
     @Index('idx_translation_wger_id')
-    @Column({ unique: true })
+    @Column({ unique: true, nullable: true })
     wgerId: number;
 
     @ManyToOne(() => Exercise, (e) => e.translations, { onDelete: 'CASCADE' })


### PR DESCRIPTION
## Summary
- permit `wgerId` to be nullable in `ExerciseTranslation` entity to avoid sync failures when existing data lacks IDs

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe member access .code on an `any` value, Unsafe assignment of an error typed value, Unsafe call of a(n) `error` type typed value, Unsafe member access .compare on an `error` typed value, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68aa360572e88332bd98a7aa9cbd35c4