### PR TITLE
Filter exercises to English and Hebrew translations

### DIFF
--- a/backend/src/modules/exercises/exercises.service.ts
+++ b/backend/src/modules/exercises/exercises.service.ts
@@ -49,7 +49,12 @@ export class ExercisesService implements OnModuleInit {
   }
 
   findOne(id: number) {
-    return this.exerciseRepo.findOneOrFail({ where: { id }, relations: ['translations', 'videos'] });
+    return this.exerciseRepo
+      .createQueryBuilder('e')
+      .leftJoinAndSelect('e.translations', 't', 't.language IN (:...langs)', { langs: [21, 2] })
+      .leftJoinAndSelect('e.videos', 'v')
+      .where('e.id = :id', { id })
+      .getOneOrFail();
   }
 
   async update(id: number, dto: UpdateExerciseDto) {
@@ -104,6 +109,7 @@ export class ExercisesService implements OnModuleInit {
     }
 
     for (const t of trData.results ?? []) {
+      if (![21, 2].includes(t.language)) continue;
       const exercise = await this.exerciseRepo.findOne({ where: { wgerId: t.exercise } });
       if (!exercise) continue;
       let translation = await this.translationRepo.findOne({ where: { wgerId: t.id } });


### PR DESCRIPTION
## Summary
- only return English and Hebrew exercise translations
- ignore other languages when syncing exercises from Wger

## Testing
- `npm test` *(backend)*
- `npm run lint` *(fails: Unsafe assignment and member access issues in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68aa390d84188332b3528556e5e2574d