### PR TITLE
Filter exercises to English/Hebrew and fix program API URL

### DIFF
--- a/backend/src/modules/exercises/exercises.service.ts
+++ b/backend/src/modules/exercises/exercises.service.ts
@@ -39,7 +39,9 @@ export class ExercisesService implements OnModuleInit {
   async findAll() {
     const exercises = await this.exerciseRepo
       .createQueryBuilder('e')
-      .leftJoinAndSelect('e.translations', 't', 't.language IN (:...langs)', { langs: [21, 2] })
+      .innerJoinAndSelect('e.translations', 't', 't.language IN (:...langs)', {
+        langs: [21, 2],
+      })
       .leftJoinAndSelect('e.videos', 'v')
       .getMany();
     if (exercises.length === 0) {
@@ -51,7 +53,9 @@ export class ExercisesService implements OnModuleInit {
   findOne(id: number) {
     return this.exerciseRepo
       .createQueryBuilder('e')
-      .leftJoinAndSelect('e.translations', 't', 't.language IN (:...langs)', { langs: [21, 2] })
+      .innerJoinAndSelect('e.translations', 't', 't.language IN (:...langs)', {
+        langs: [21, 2],
+      })
       .leftJoinAndSelect('e.videos', 'v')
       .where('e.id = :id', { id })
       .getOneOrFail();
@@ -86,10 +90,12 @@ export class ExercisesService implements OnModuleInit {
     for (const item of exData.results ?? []) {
       let name = item.name as string | undefined;
       if (!name) {
-        const fallback = trData.results?.find((t) => t.exercise === item.id);
+        const fallback = trData.results?.find(
+          (t) => t.exercise === item.id && [21, 2].includes(t.language),
+        );
         name = fallback?.name;
         if (!name) {
-          continue; // skip exercises without any name
+          continue; // skip exercises without English or Hebrew name
         }
         item.description = item.description ?? fallback.description;
       }

--- a/frontend/src/services/trainingPrograms.ts
+++ b/frontend/src/services/trainingPrograms.ts
@@ -23,8 +23,10 @@ export async function createProgram(program: Program) {
             rest: sanitize(e.rest),
         })),
     };
-    const apiUrl = import.meta.env.VITE_API_URL;
-    const res = await fetch(`${apiUrl}/training-programs`, {
+    const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+    // build URL correctly whether apiUrl has a trailing slash or not
+    const url = new URL('training-programs', apiUrl.endsWith('/') ? apiUrl : apiUrl + '/').toString();
+    const res = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(sanitized),


### PR DESCRIPTION
## Summary
- only load exercises that have English or Hebrew translations
- fix training program creation by defaulting API URL

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa3b56d3088332b9bae632fb84eba6