### PR TITLE
Fetch exercises with translations for program editor

### DIFF
--- a/backend/src/modules/exercises/exercises.service.ts
+++ b/backend/src/modules/exercises/exercises.service.ts
@@ -39,9 +39,12 @@ export class ExercisesService implements OnModuleInit {
   async findAll() {
     const exercises = await this.exerciseRepo
       .createQueryBuilder('e')
-      .innerJoinAndSelect('e.translations', 't', 't.language IN (:...langs)', {
-        langs: [21, 2],
-      })
+      .leftJoinAndSelect(
+        'e.translations',
+        't',
+        '(t.language = :lang1 OR t.language = :lang2)',
+        { lang1: 2, lang2: 21 },
+      )
       .leftJoinAndSelect('e.videos', 'v')
       .getMany();
     if (exercises.length === 0) {
@@ -53,9 +56,12 @@ export class ExercisesService implements OnModuleInit {
   findOne(id: number) {
     return this.exerciseRepo
       .createQueryBuilder('e')
-      .innerJoinAndSelect('e.translations', 't', 't.language IN (:...langs)', {
-        langs: [21, 2],
-      })
+      .leftJoinAndSelect(
+        'e.translations',
+        't',
+        '(t.language = :lang1 OR t.language = :lang2)',
+        { lang1: 2, lang2: 21 },
+      )
       .leftJoinAndSelect('e.videos', 'v')
       .where('e.id = :id', { id })
       .getOneOrFail();

--- a/frontend/src/components/ExerciseSelector.tsx
+++ b/frontend/src/components/ExerciseSelector.tsx
@@ -13,7 +13,7 @@ export default function ExerciseSelector({ value, onChange }: Props) {
 
     useEffect(() => {
         const fetchExercises = async () => {
-            const apiUrl = "http://localhost:3001";
+            const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
             if (!apiUrl) {
                 console.error('VITE_API_URL is missing');
                 return;
@@ -41,8 +41,13 @@ export default function ExerciseSelector({ value, onChange }: Props) {
                     );
                 }
 
-                const data: Array<{ name?: string | null }> = await res.json();
-                const names = (data || []).map((e) => sanitize(e?.name)).filter(Boolean) as string[];
+                const data: Array<{ name?: string | null; translations?: Array<{ name?: string | null; language?: number }> }> = await res.json();
+                const names = (data || [])
+                    .map((e) => {
+                        const t = e.translations?.find((tr) => tr.language === 2 || tr.language === 21);
+                        return sanitize(t?.name || e?.name);
+                    })
+                    .filter(Boolean) as string[];
                 setOptions(names);
             } catch (err) {
                 console.error('Failed to load exercises:', err);


### PR DESCRIPTION
## Summary
- return exercises with translations and videos using left joins in backend service
- load exercise translations on Program Edit page for SearchableSelect using API URL

## Testing
- `npm test` (backend)
- `npm run lint` (backend)
- `npm test` (frontend, fails: Missing script: "test")
- `npm run lint` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68aa45f378808332bcbe8c6aea751ebd