### PR TITLE
Prioritize Hebrew exercises and avoid duplicate select entries

### DIFF
--- a/frontend/src/components/ExerciseSelector.tsx
+++ b/frontend/src/components/ExerciseSelector.tsx
@@ -44,11 +44,12 @@ export default function ExerciseSelector({ value, onChange }: Props) {
                 const data: Array<{ name?: string | null; translations?: Array<{ name?: string | null; language?: number }> }> = await res.json();
                 const names = (data || [])
                     .map((e) => {
-                        const t = e.translations?.find((tr) => tr.language === 2 || tr.language === 21);
-                        return sanitize(t?.name || e?.name);
+                        const heb = e.translations?.find((tr) => tr.language === 21);
+                        const other = e.translations?.find((tr) => tr.language === 2);
+                        return sanitize(heb?.name || other?.name || e?.name);
                     })
                     .filter(Boolean) as string[];
-                setOptions(names);
+                setOptions(Array.from(new Set(names)));
             } catch (err) {
                 console.error('Failed to load exercises:', err);
                 setOptions([]); // fail safe
@@ -56,6 +57,17 @@ export default function ExerciseSelector({ value, onChange }: Props) {
         };
         fetchExercises();
     }, []);
+
+    useEffect(() => {
+        if (value) {
+            setOptions((prev) => {
+                if (prev.includes(value)) {
+                    return prev;
+                }
+                return [...prev, value];
+            });
+        }
+    }, [value]);
 
     return (
         <SearchableSelect

--- a/frontend/src/components/ui/SearchableSelect.tsx
+++ b/frontend/src/components/ui/SearchableSelect.tsx
@@ -10,7 +10,8 @@ interface Props {
 
 export default function SearchableSelect({ options, value, onChange, placeholder, inputClassName }: Props) {
     const [open, setOpen] = useState(false);
-    const filtered = options.filter((opt) => opt.toLowerCase().includes(value.toLowerCase()));
+    const uniqueOptions = Array.from(new Set(options));
+    const filtered = uniqueOptions.filter((opt) => opt.toLowerCase().includes(value.toLowerCase()));
 
     const handleSelect = (opt: string) => {
         onChange(opt);


### PR DESCRIPTION
## Summary
- Prefer Hebrew exercise names and deduplicate exercise options
- Ensure selected exercise values are added to the option list
- Remove duplicate entries in the SearchableSelect component

## Testing
- `npm --prefix frontend test` *(fails: Missing script: "test")*
- `npm --prefix frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_68aa481e60b483328bee96cfb46ba8b3