### PR TITLE
Fix program creation and cache exercise list

### DIFF
--- a/frontend/src/components/ExerciseSelector.tsx
+++ b/frontend/src/components/ExerciseSelector.tsx
@@ -8,54 +8,74 @@ interface Props {
 
 const sanitize = (v?: string | null) => (v ?? '').replace(/<[^>]*>?/gm, '');
 
-export default function ExerciseSelector({ value, onChange }: Props) {
-    const [options, setOptions] = useState<string[]>([]);
+let cachedOptions: string[] | null = null;
+let loadPromise: Promise<string[]> | null = null;
 
-    useEffect(() => {
-        const fetchExercises = async () => {
+async function loadExercises(): Promise<string[]> {
+    if (cachedOptions) {
+        return cachedOptions;
+    }
+
+    if (!loadPromise) {
+        loadPromise = (async () => {
             const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
             if (!apiUrl) {
                 console.error('VITE_API_URL is missing');
-                return;
+                return [];
             }
 
             // builds `${apiUrl}/exercises` correctly whether or not apiUrl has a trailing slash
             const url = new URL('exercises', apiUrl.endsWith('/') ? apiUrl : apiUrl + '/').toString();
 
-            try {
-                const res = await fetch(url, {
-                    headers: { Accept: 'application/json' },
-                    credentials: 'include', // keep if your API uses cookies/sessions; otherwise remove
-                });
+            const res = await fetch(url, {
+                headers: { Accept: 'application/json' },
+                credentials: 'include', // keep if your API uses cookies/sessions; otherwise remove
+            });
 
-                if (!res.ok) {
-                    const text = await res.text().catch(() => '');
-                    throw new Error(`HTTP ${res.status} – ${res.statusText}\n${text.slice(0, 500)}`);
-                }
-
-                const ct = res.headers.get('content-type') || '';
-                if (!ct.includes('application/json')) {
-                    const text = await res.text();
-                    throw new Error(
-                        `Expected JSON but got "${ct || 'unknown'}". Body preview:\n${text.slice(0, 500)}`
-                    );
-                }
-
-                const data: Array<{ name?: string | null; translations?: Array<{ name?: string | null; language?: number }> }> = await res.json();
-                const names = (data || [])
-                    .map((e) => {
-                        const heb = e.translations?.find((tr) => tr.language === 21);
-                        const other = e.translations?.find((tr) => tr.language === 2);
-                        return sanitize(heb?.name || other?.name || e?.name);
-                    })
-                    .filter(Boolean) as string[];
-                setOptions(Array.from(new Set(names)));
-            } catch (err) {
-                console.error('Failed to load exercises:', err);
-                setOptions([]); // fail safe
+            if (!res.ok) {
+                const text = await res.text().catch(() => '');
+                throw new Error(`HTTP ${res.status} – ${res.statusText}\n${text.slice(0, 500)}`);
             }
+
+            const ct = res.headers.get('content-type') || '';
+            if (!ct.includes('application/json')) {
+                const text = await res.text();
+                throw new Error(`Expected JSON but got "${ct || 'unknown'}". Body preview:\n${text.slice(0, 500)}`);
+            }
+
+            const data: Array<{ name?: string | null; translations?: Array<{ name?: string | null; language?: number }> }> = await res.json();
+            const names = (data || [])
+                .map((e) => {
+                    const heb = e.translations?.find((tr) => tr.language === 21);
+                    const other = e.translations?.find((tr) => tr.language === 2);
+                    return sanitize(heb?.name || other?.name || e?.name);
+                })
+                .filter(Boolean) as string[];
+            cachedOptions = Array.from(new Set(names));
+            return cachedOptions;
+        })().catch((err) => {
+            console.error('Failed to load exercises:', err);
+            cachedOptions = [];
+            return cachedOptions;
+        });
+    }
+
+    return loadPromise;
+}
+
+export default function ExerciseSelector({ value, onChange }: Props) {
+    const [options, setOptions] = useState<string[]>([]);
+
+    useEffect(() => {
+        let isMounted = true;
+        loadExercises().then((opts) => {
+            if (isMounted) {
+                setOptions(opts);
+            }
+        });
+        return () => {
+            isMounted = false;
         };
-        fetchExercises();
     }, []);
 
     useEffect(() => {

--- a/frontend/src/pages/ProgramEdit.tsx
+++ b/frontend/src/pages/ProgramEdit.tsx
@@ -8,6 +8,7 @@ import { createProgram, type Program } from '../services/trainingPrograms';
 interface Exercise {
     name: string;
     sets: string;
+    reps: string;
     weight: string;
     rest: string;
 }
@@ -24,7 +25,7 @@ export default function ProgramEdit() {
     const id = params.id ? Number(sanitize(params.id)) : undefined;
     const [program, setProgram] = useState<LocalProgram>({
         name: '',
-        exercises: [{ name: '', sets: '', weight: '', rest: '' }],
+        exercises: [{ name: '', sets: '', reps: '', weight: '', rest: '' }],
     });
 
     useEffect(() => {
@@ -40,7 +41,7 @@ export default function ProgramEdit() {
     const addExercise = () => {
         setProgram({
             ...program,
-            exercises: [...program.exercises, { name: '', sets: '', weight: '', rest: '' }],
+            exercises: [...program.exercises, { name: '', sets: '', reps: '', weight: '', rest: '' }],
         });
     };
 
@@ -84,11 +85,19 @@ export default function ProgramEdit() {
                             />
                         </label>
                         <label className="program-edit__field">
-                            <span className="program-edit__label">מספר חזרות</span>
+                            <span className="program-edit__label">סטים</span>
                             <input
                                 className="program-edit__input"
                                 value={exercise.sets}
                                 onChange={(e) => updateExercise(idx, 'sets', e.target.value)}
+                            />
+                        </label>
+                        <label className="program-edit__field">
+                            <span className="program-edit__label">חזרות</span>
+                            <input
+                                className="program-edit__input"
+                                value={exercise.reps}
+                                onChange={(e) => updateExercise(idx, 'reps', e.target.value)}
                             />
                         </label>
                         <label className="program-edit__field">

--- a/frontend/src/services/trainingPrograms.ts
+++ b/frontend/src/services/trainingPrograms.ts
@@ -3,6 +3,7 @@ const sanitize = (v: string) => v.replace(/<[^>]*>?/gm, '').trim();
 export interface Exercise {
     name: string;
     sets: string;
+    reps: string;
     weight: string;
     rest: string;
 }
@@ -10,17 +11,22 @@ export interface Exercise {
 export interface Program {
     name: string;
     exercises: Exercise[];
+    difficultyLevel?: 'beginner' | 'intermediate' | 'advanced';
+    workoutType?: string;
 }
 
 export async function createProgram(program: Program) {
     const sanitized = {
         ...program,
         name: sanitize(program.name),
+        difficultyLevel: program.difficultyLevel ?? 'beginner',
+        workoutType: program.workoutType ?? 'general',
         exercises: program.exercises.map((e) => ({
             name: sanitize(e.name),
-            sets: sanitize(e.sets),
+            sets: Number(sanitize(e.sets)) || 1,
+            reps: sanitize(e.reps),
             weight: sanitize(e.weight),
-            rest: sanitize(e.rest),
+            notes: sanitize(e.rest),
         })),
     };
     const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';


### PR DESCRIPTION
## Summary
- add sets and reps fields to program editor and send required defaults
- cache exercise list to avoid redundant API requests
- include difficulty level and workout type when creating programs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa4946aad883329208daf18dd42481