### PR TITLE
fix: validate training program sets as numbers

### DIFF
--- a/backend/src/modules/training-programs/dto/create-training-program.dto.ts
+++ b/backend/src/modules/training-programs/dto/create-training-program.dto.ts
@@ -1,9 +1,22 @@
-import { IsString, IsEnum, IsOptional, IsArray, ValidateNested, IsBoolean } from 'class-validator';
+import {
+    IsString,
+    IsEnum,
+    IsOptional,
+    IsArray,
+    ValidateNested,
+    IsBoolean,
+    IsInt,
+    Min,
+    Max,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
 class ProgramExerciseDto {
     @IsString() name: string;
-    @IsEnum(['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'], { each: false, message: 'sets must be a number' })
+    @Type(() => Number)
+    @IsInt({ message: 'sets must be a number' })
+    @Min(1)
+    @Max(10)
     sets: number;
     @IsString() reps: string;
     @IsString() weight: string;


### PR DESCRIPTION
## Summary
- ensure training program exercise sets are validated as integers with bounds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa4b3e1bb48332a3f0368bea5d344e