### PR TITLE
Align training program schema and expand program form

### DIFF
--- a/backend/src/modules/training-programs/dto/create-training-program.dto.ts
+++ b/backend/src/modules/training-programs/dto/create-training-program.dto.ts
@@ -20,7 +20,7 @@ class ProgramExerciseDto {
     sets: number;
     @IsString() reps: string;
     @IsString() weight: string;
-    @IsOptional() @IsString() notes?: string;
+    @IsOptional() @IsString() rest?: string;
 }
 
 export class CreateTrainingProgramDto {

--- a/backend/src/modules/training-programs/entities/training-program.entity.ts
+++ b/backend/src/modules/training-programs/entities/training-program.entity.ts
@@ -5,33 +5,33 @@ export interface ProgramExercise {
     sets: number;
     reps: string;
     weight: string;
-    notes?: string;
+    rest?: string;
 }
 
-@Entity()
+@Entity('training_programs')
 export class TrainingProgram {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Column({ length: 200 })
+    @Column({ name: 'name', length: 200 })
     name: string;
 
-    @Column({ type: 'text', nullable: true })
+    @Column({ name: 'description', type: 'text', nullable: true })
     description?: string;
 
-    @Column({ type: 'varchar', length: 20 })
+    @Column({ name: 'difficulty_level', type: 'varchar', length: 20 })
     difficultyLevel: 'beginner' | 'intermediate' | 'advanced';
 
     // stored as JSONB
-    @Column({ type: 'jsonb', nullable: true })
+    @Column({ name: 'exercises', type: 'jsonb', nullable: true })
     exercises?: ProgramExercise[];
 
-    @Column({ length: 100 })
+    @Column({ name: 'workout_type', length: 100 })
     workoutType: string;
 
-    @Column({ length: 50, nullable: true })
+    @Column({ name: 'time_cap', length: 50, nullable: true })
     timeCap?: string;
 
-    @Column({ default: true })
+    @Column({ name: 'is_template', default: true })
     isTemplate: boolean;
 }

--- a/backend/src/modules/training-programs/training-programs.service.ts
+++ b/backend/src/modules/training-programs/training-programs.service.ts
@@ -25,7 +25,7 @@ export class TrainingProgramsService {
         name: sanitizeInput(e.name),
         reps: sanitizeInput(e.reps),
         weight: sanitizeInput(e.weight),
-        notes: e.notes ? sanitizeInput(e.notes) : undefined,
+        rest: e.rest ? sanitizeInput(e.rest) : undefined,
       })),
     };
     const tp = this.repo.create(sanitized);
@@ -52,7 +52,7 @@ export class TrainingProgramsService {
         name: sanitizeInput(e.name),
         reps: sanitizeInput(e.reps),
         weight: sanitizeInput(e.weight),
-        notes: e.notes ? sanitizeInput(e.notes) : undefined,
+        rest: e.rest ? sanitizeInput(e.rest) : undefined,
       })),
     };
     await this.repo.update(id, sanitized);

--- a/frontend/src/components/layout/ExerciseList.tsx
+++ b/frontend/src/components/layout/ExerciseList.tsx
@@ -6,7 +6,6 @@ interface Exercise {
     reps?: number | string;
     weight?: number | string;
     rest?: string;
-    notes?: string;
 }
 
 export default function ExerciseList({ exercises = [] }: { exercises: Exercise[] }) {

--- a/frontend/src/components/layout/TrainingMonitorCube.tsx
+++ b/frontend/src/components/layout/TrainingMonitorCube.tsx
@@ -8,7 +8,6 @@ interface Exercise {
     reps?: number | string;
     weight?: number | string;
     rest?: string;
-    notes?: string;
 }
 
 interface Props {

--- a/frontend/src/pages/ProgramEdit.tsx
+++ b/frontend/src/pages/ProgramEdit.tsx
@@ -25,6 +25,10 @@ export default function ProgramEdit() {
     const id = params.id ? Number(sanitize(params.id)) : undefined;
     const [program, setProgram] = useState<LocalProgram>({
         name: '',
+        description: '',
+        difficultyLevel: 'beginner',
+        workoutType: '',
+        isTemplate: true,
         exercises: [{ name: '', sets: '', reps: '', weight: '', rest: '' }],
     });
 
@@ -53,7 +57,13 @@ export default function ProgramEdit() {
     const saveProgram = async (e: React.FormEvent) => {
         e.preventDefault();
         try {
-            await createProgram({ name: sanitize(program.name), exercises: program.exercises });
+            await createProgram({
+                ...program,
+                name: sanitize(program.name),
+                description: sanitize(program.description || ''),
+                workoutType: sanitize(program.workoutType),
+                exercises: program.exercises,
+            });
             navigate('/programs');
         } catch (err) {
             console.error(err);
@@ -72,6 +82,56 @@ export default function ProgramEdit() {
                         value={program.name}
                         onChange={(e) => setProgram({ ...program, name: sanitize(e.target.value) })}
                         required
+                    />
+                </label>
+
+                <label className="program-edit__field">
+                    <span className="program-edit__label">תיאור</span>
+                    <textarea
+                        className="program-edit__input"
+                        value={program.description}
+                        onChange={(e) => setProgram({ ...program, description: sanitize(e.target.value) })}
+                    />
+                </label>
+
+                <label className="program-edit__field">
+                    <span className="program-edit__label">רמת קושי</span>
+                    <select
+                        className="program-edit__input"
+                        value={program.difficultyLevel}
+                        onChange={(e) =>
+                            setProgram({
+                                ...program,
+                                difficultyLevel: e.target.value as
+                                    | 'beginner'
+                                    | 'intermediate'
+                                    | 'advanced',
+                            })
+                        }
+                    >
+                        <option value="beginner">מתחיל</option>
+                        <option value="intermediate">בינוני</option>
+                        <option value="advanced">מתקדם</option>
+                    </select>
+                </label>
+
+                <label className="program-edit__field">
+                    <span className="program-edit__label">סוג אימון</span>
+                    <input
+                        className="program-edit__input"
+                        value={program.workoutType}
+                        onChange={(e) =>
+                            setProgram({ ...program, workoutType: sanitize(e.target.value) })
+                        }
+                    />
+                </label>
+
+                <label className="program-edit__field">
+                    <span className="program-edit__label">תבנית?</span>
+                    <input
+                        type="checkbox"
+                        checked={program.isTemplate}
+                        onChange={(e) => setProgram({ ...program, isTemplate: e.target.checked })}
                     />
                 </label>
 

--- a/frontend/src/services/trainingPrograms.ts
+++ b/frontend/src/services/trainingPrograms.ts
@@ -11,22 +11,26 @@ export interface Exercise {
 export interface Program {
     name: string;
     exercises: Exercise[];
+    description?: string;
     difficultyLevel?: 'beginner' | 'intermediate' | 'advanced';
     workoutType?: string;
+    isTemplate?: boolean;
 }
 
 export async function createProgram(program: Program) {
     const sanitized = {
         ...program,
         name: sanitize(program.name),
+        description: program.description ? sanitize(program.description) : undefined,
         difficultyLevel: program.difficultyLevel ?? 'beginner',
-        workoutType: program.workoutType ?? 'general',
+        workoutType: sanitize(program.workoutType ?? 'general'),
+        isTemplate: program.isTemplate ?? true,
         exercises: program.exercises.map((e) => ({
             name: sanitize(e.name),
             sets: Number(sanitize(e.sets)) || 1,
             reps: sanitize(e.reps),
             weight: sanitize(e.weight),
-            notes: sanitize(e.rest),
+            rest: sanitize(e.rest),
         })),
     };
     const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';

--- a/frontend/src/store/slices/api/Trainee.ts
+++ b/frontend/src/store/slices/api/Trainee.ts
@@ -3,7 +3,7 @@ export interface ProgramExercise {
     sets: number;
     reps: string;
     weight: string;
-    notes?: string;
+    rest?: string;
 }
 
 export interface TrainingProgram {


### PR DESCRIPTION
## Summary
- Map training program entity to existing `training_programs` table and replace exercise notes with rest period
- Support description, workout type, difficulty level, and template flag when creating programs
- Add corresponding inputs on the program edit page and send new fields to the backend

## Testing
- `cd backend && npm test`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa4f7f14d083329040da0e0f887349