### PR TITLE
Load training programs from backend

### DIFF
--- a/frontend/src/components/TrainingProgramModal.tsx
+++ b/frontend/src/components/TrainingProgramModal.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useState } from 'react';
 import SearchableSelect from './ui/SearchableSelect';
-
-interface Program {
-    id: number;
-    name: string;
-}
+import { getPrograms, type Program } from '../services/trainingPrograms';
 
 interface Props {
     isOpen: boolean;
@@ -18,8 +14,9 @@ export default function TrainingProgramModal({ isOpen, onClose }: Props) {
 
     useEffect(() => {
         if (isOpen) {
-            const stored = localStorage.getItem('programs');
-            if (stored) setPrograms(JSON.parse(stored));
+            getPrograms()
+                .then(setPrograms)
+                .catch((err) => console.error(err));
         }
     }, [isOpen]);
 

--- a/frontend/src/pages/ProgramManagement.tsx
+++ b/frontend/src/pages/ProgramManagement.tsx
@@ -2,36 +2,29 @@ import { faPen, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-
-interface Program {
-    id: number;
-    name: string;
-}
-
-const seedPrograms: Program[] = [
-    { id: 1, name: 'תוכנית כוח' },
-    { id: 2, name: 'תוכנית קרדיו' },
-    { id: 3, name: 'תוכנית שיקום' },
-];
+import {
+    getPrograms,
+    deleteProgram,
+    type Program,
+} from '../services/trainingPrograms';
 
 export default function ProgramManagement() {
     const navigate = useNavigate();
     const [programs, setPrograms] = useState<Program[]>([]);
 
     useEffect(() => {
-        const stored = localStorage.getItem('programs');
-        if (stored) {
-            setPrograms(JSON.parse(stored));
-        } else {
-            localStorage.setItem('programs', JSON.stringify(seedPrograms));
-            setPrograms(seedPrograms);
-        }
+        getPrograms()
+            .then(setPrograms)
+            .catch((err) => console.error(err));
     }, []);
 
-    const removeProgram = (id: number) => {
-        const updated = programs.filter((p) => p.id !== id);
-        setPrograms(updated);
-        localStorage.setItem('programs', JSON.stringify(updated));
+    const removeProgram = async (id: number) => {
+        try {
+            await deleteProgram(id);
+            setPrograms((prev) => prev.filter((p) => p.id !== id));
+        } catch (err) {
+            console.error(err);
+        }
     };
 
     const startEdit = (id?: number) => {

--- a/frontend/src/services/trainingPrograms.ts
+++ b/frontend/src/services/trainingPrograms.ts
@@ -9,6 +9,7 @@ export interface Exercise {
 }
 
 export interface Program {
+    id?: number;
     name: string;
     exercises: Exercise[];
     description?: string;
@@ -46,4 +47,25 @@ export async function createProgram(program: Program) {
         throw new Error(msg || 'Failed to save');
     }
     return res.json();
+}
+
+export async function getPrograms(): Promise<Program[]> {
+    const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+    const url = new URL('training-programs', apiUrl.endsWith('/') ? apiUrl : apiUrl + '/').toString();
+    const res = await fetch(url);
+    if (!res.ok) {
+        const msg = await res.text();
+        throw new Error(msg || 'Failed to load');
+    }
+    return res.json();
+}
+
+export async function deleteProgram(id: number): Promise<void> {
+    const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+    const url = new URL(`training-programs/${id}`, apiUrl.endsWith('/') ? apiUrl : apiUrl + '/').toString();
+    const res = await fetch(url, { method: 'DELETE' });
+    if (!res.ok) {
+        const msg = await res.text();
+        throw new Error(msg || 'Failed to delete');
+    }
 }


### PR DESCRIPTION
## Summary
- Fetch existing training programs from the backend and support deletion
- Populate the program management page and training program modal with API data instead of local storage

## Testing
- `npm run lint`
- `npm run build` *(fails: ExerciseList.tsx: 'React' is declared but its value is never read)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa51923ccc8332bbbe3ce486d43365