### PR TITLE
Add training time table and user details

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { TrainingProgramsModule } from './modules/training-programs/training-pro
 import { TraineesModule } from './modules/trainees/trainees.module';
 import { TrainingLogsModule } from './modules/training-logs/training-logs.module';
 import { ExercisesModule } from './modules/exercises/exercises.module';
+import { TrainingTimesModule } from './modules/training-times/training-times.module';
 
 @Module({
 	imports: [
@@ -22,6 +23,7 @@ import { ExercisesModule } from './modules/exercises/exercises.module';
                 TraineesModule,
                 TrainingLogsModule,
                 ExercisesModule,
+                TrainingTimesModule,
         ],
 	controllers: [],
 	providers: [],

--- a/backend/src/database/db-init.service.ts
+++ b/backend/src/database/db-init.service.ts
@@ -11,7 +11,9 @@ export class DbInitService implements OnModuleInit {
       CREATE TABLE users (
         id SERIAL PRIMARY KEY,
         first_name VARCHAR(100),
+        name VARCHAR(200),
         last_name VARCHAR(100),
+        details TEXT,
         email VARCHAR(255) UNIQUE,
         phone_num VARCHAR(20) UNIQUE,
         password VARCHAR(255),
@@ -30,6 +32,8 @@ export class DbInitService implements OnModuleInit {
         created_at TIMESTAMP DEFAULT now(),
         updated_at TIMESTAMP DEFAULT now()
       );
+      INSERT INTO users (name, email, details)
+      VALUES ('Test User', 'test@example.com', 'Sample user');
     `,
     notifications: `
       CREATE TABLE notifications (
@@ -219,6 +223,20 @@ export class DbInitService implements OnModuleInit {
         created_at TIMESTAMP DEFAULT now(),
         updated_at TIMESTAMP DEFAULT now()
       );
+      INSERT INTO training_programs (name, description, difficulty_level, workout_type, is_template)
+      VALUES ('Sample Program', 'Demo program', 'beginner', 'general', true);
+    `,
+    training_times: `
+      CREATE TABLE training_times (
+        id SERIAL PRIMARY KEY,
+        user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+        training_time TIMESTAMP NOT NULL,
+        program_id INTEGER REFERENCES training_programs(id) ON DELETE SET NULL,
+        details JSONB
+      );
+      CREATE INDEX idx_training_times_user ON training_times(user_id);
+      INSERT INTO training_times (user_id, training_time, program_id, details)
+      VALUES (1, NOW(), 1, '{}');
     `,
   };
 
@@ -242,6 +260,7 @@ export class DbInitService implements OnModuleInit {
     { tbl_name: 'exercise_equipment', dependencies: ['exercises', 'equipment'] },
     { tbl_name: 'workout_types', dependencies: [] },
     { tbl_name: 'training_programs', dependencies: [] },
+    { tbl_name: 'training_times', dependencies: ['users', 'training_programs'] },
   ];
 
   constructor(private dataSource: DataSource) { }

--- a/backend/src/modules/training-times/dto/create-training-time.dto.ts
+++ b/backend/src/modules/training-times/dto/create-training-time.dto.ts
@@ -1,0 +1,17 @@
+import { IsInt, IsOptional, IsDateString, IsObject } from 'class-validator';
+
+export class CreateTrainingTimeDto {
+  @IsInt()
+  userId: number;
+
+  @IsDateString()
+  trainingTime: string;
+
+  @IsInt()
+  @IsOptional()
+  programId?: number;
+
+  @IsOptional()
+  @IsObject()
+  details?: Record<string, unknown>;
+}

--- a/backend/src/modules/training-times/entities/training-time.entity.ts
+++ b/backend/src/modules/training-times/entities/training-time.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, Column } from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { TrainingProgram } from '../../training-programs/entities/training-program.entity';
+
+@Entity('training_times')
+export class TrainingTime {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, { eager: true, onDelete: 'CASCADE' })
+  user: User;
+
+  @Column({ type: 'timestamp' })
+  training_time: Date;
+
+  @ManyToOne(() => TrainingProgram, { eager: true, nullable: true, onDelete: 'SET NULL' })
+  program?: TrainingProgram | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  details?: Record<string, unknown>;
+}

--- a/backend/src/modules/training-times/training-times.controller.ts
+++ b/backend/src/modules/training-times/training-times.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Post, Body } from '@nestjs/common';
+import { TrainingTimesService } from './training-times.service';
+import { CreateTrainingTimeDto } from './dto/create-training-time.dto';
+
+@Controller('training-times')
+export class TrainingTimesController {
+  constructor(private readonly service: TrainingTimesService) {}
+
+  @Post()
+  create(@Body() dto: CreateTrainingTimeDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+}

--- a/backend/src/modules/training-times/training-times.module.ts
+++ b/backend/src/modules/training-times/training-times.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TrainingTimesService } from './training-times.service';
+import { TrainingTimesController } from './training-times.controller';
+import { TrainingTime } from './entities/training-time.entity';
+import { User } from '../users/entities/user.entity';
+import { TrainingProgram } from '../training-programs/entities/training-program.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TrainingTime, User, TrainingProgram])],
+  controllers: [TrainingTimesController],
+  providers: [TrainingTimesService],
+})
+export class TrainingTimesModule {}

--- a/backend/src/modules/training-times/training-times.service.ts
+++ b/backend/src/modules/training-times/training-times.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, NotFoundException, InternalServerErrorException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TrainingTime } from './entities/training-time.entity';
+import { CreateTrainingTimeDto } from './dto/create-training-time.dto';
+import { User } from '../users/entities/user.entity';
+import { TrainingProgram } from '../training-programs/entities/training-program.entity';
+
+@Injectable()
+export class TrainingTimesService {
+  constructor(
+    @InjectRepository(TrainingTime) private readonly repo: Repository<TrainingTime>,
+    @InjectRepository(User) private readonly userRepo: Repository<User>,
+    @InjectRepository(TrainingProgram) private readonly programRepo: Repository<TrainingProgram>,
+  ) {}
+
+  async create(dto: CreateTrainingTimeDto) {
+    try {
+      const user = await this.userRepo.findOne({ where: { id: dto.userId } });
+      if (!user) throw new NotFoundException('User not found');
+      let program: TrainingProgram | null = null;
+      if (dto.programId) {
+        program = await this.programRepo.findOne({ where: { id: dto.programId } });
+        if (!program) throw new NotFoundException('Program not found');
+      }
+      const entity = this.repo.create({
+        user,
+        training_time: new Date(dto.trainingTime),
+        program: program ?? undefined,
+        details: dto.details,
+      });
+      return await this.repo.save(entity);
+    } catch (err) {
+      if (err instanceof NotFoundException) throw err;
+      throw new InternalServerErrorException('Failed to create training time');
+    }
+  }
+
+  async findAll() {
+    try {
+      return await this.repo.find();
+    } catch {
+      throw new InternalServerErrorException('Failed to fetch training times');
+    }
+  }
+}

--- a/backend/src/modules/users/dto/create-user.dto.ts
+++ b/backend/src/modules/users/dto/create-user.dto.ts
@@ -6,10 +6,19 @@ export class CreateUserDto {
     @IsString()
     first_name: string;
 
+    @IsOptional()
+    @Length(1, 200)
+    @IsString()
+    name?: string;
+
     @Length(2, 100)
     @IsOptional()
     @IsString()
     last_name: string;
+
+    @IsOptional()
+    @IsString()
+    details?: string;
 
     @IsNotEmpty()
     @IsEmail()

--- a/backend/src/modules/users/dto/update-user.dto.ts
+++ b/backend/src/modules/users/dto/update-user.dto.ts
@@ -6,8 +6,15 @@ export class UpdateUserDto {
     first_name?: string;
 
     @IsOptional()
+    @Length(1, 200)
+    name?: string;
+
+    @IsOptional()
     @Length(1, 100)
     last_name?: string;
+
+    @IsOptional()
+    details?: string;
 
     @IsOptional()
     @IsEmail()

--- a/backend/src/modules/users/entities/user.entity.ts
+++ b/backend/src/modules/users/entities/user.entity.ts
@@ -18,11 +18,17 @@ export class User {
     @Column({ nullable: true })
     first_name?: string;
 
+    @Column({ length: 200, nullable: true })
+    name?: string;
+
     @Column({ type: 'varchar', length: 50, nullable: true })
     recovery_code: string | null;
 
     @Column({ length: 100, nullable: true })
     last_name?: string;
+
+    @Column({ type: 'text', nullable: true })
+    details?: string;
 
     @Column({ length: 255, unique: true, nullable: true })
     email?: string;

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -22,14 +22,16 @@ export class UsersService {
 		private readonly roleRepository: Repository<Role>,
 	) { }
 
-	async create(createUserDto: CreateUserDto): Promise<User> {
-		try {
-			const user = this.userRepository.create({
-				first_name: createUserDto.first_name,
-				last_name: createUserDto.last_name,
-				email: createUserDto.email,
-				password: createUserDto.password,
-			});
+        async create(createUserDto: CreateUserDto): Promise<User> {
+                try {
+                        const user = this.userRepository.create({
+                                first_name: createUserDto.first_name,
+                                last_name: createUserDto.last_name,
+                                name: createUserDto.name,
+                                details: createUserDto.details,
+                                email: createUserDto.email,
+                                password: createUserDto.password,
+                        });
 
 			const basic = await this.roleRepository.findOneBy({ name: 'basic' });
 			if (!basic) throw new NotFoundException('Role "basic" not found');
@@ -67,11 +69,13 @@ export class UsersService {
 
 	async update(id: number, updateUserDto: UpdateUserDto): Promise<User> {
 		try {
-			const result = await this.userRepository.update(id, {
-				first_name: updateUserDto.first_name,
-				last_name: updateUserDto.last_name,
-				email: updateUserDto.email,
-			});
+                        const result = await this.userRepository.update(id, {
+                                first_name: updateUserDto.first_name,
+                                last_name: updateUserDto.last_name,
+                                name: updateUserDto.name,
+                                details: updateUserDto.details,
+                                email: updateUserDto.email,
+                        });
 
 			if (result.affected === 0) {
 				throw new NotFoundException(`User with id ${id} not found`);

--- a/backend/src/types/User.entity.ts
+++ b/backend/src/types/User.entity.ts
@@ -2,6 +2,8 @@ export interface UserEntity {
     id: string;
     first_name: string;
     last_name: string;
+    name?: string;
+    details?: string;
     email: string;
     password?: string; // Optional, as it may not be returned in some contexts
     auth_provider: 'email' | 'google' | 'facebook' | 'apple'; // Extend as needed

--- a/frontend/src/pages/ProgramManagement.tsx
+++ b/frontend/src/pages/ProgramManagement.tsx
@@ -11,19 +11,24 @@ import {
 export default function ProgramManagement() {
     const navigate = useNavigate();
     const [programs, setPrograms] = useState<Program[]>([]);
+    const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
         getPrograms()
             .then(setPrograms)
-            .catch((err) => console.error(err));
+            .catch((err) => {
+                console.error(err);
+                setError(err.message || 'Failed to load');
+            });
     }, []);
 
     const removeProgram = async (id: number) => {
         try {
             await deleteProgram(id);
             setPrograms((prev) => prev.filter((p) => p.id !== id));
-        } catch (err) {
+        } catch (err: any) {
             console.error(err);
+            setError(err.message || 'Failed to delete');
         }
     };
 
@@ -37,7 +42,12 @@ export default function ProgramManagement() {
             <p className="program-management__subtitle">
                 יצירה ועריכה של תוכניות אימון כלליות
             </p>
-
+            {error && <p className="program-management__error">{error}</p>}
+            {programs.length === 0 && !error && (
+                <p className="program-management__empty">
+                    אין תוכניות זמינות. צור רשומה חדשה כדי להתחיל.
+                </p>
+            )}
             <ul className="program-management__list">
                 {programs.map((program) => (
                     <li key={program.id} className="program-management__item">


### PR DESCRIPTION
## Summary
- add name and details to users
- create training time table linked to users and programs with mock data
- show helpful message when training programs list is empty

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae0bb62c248332b2a32beddbc16d9f