### PR TITLE
Fetch today's trainees without Boostapp sync

### DIFF
--- a/backend/src/modules/trainees/trainee-get.controller.ts
+++ b/backend/src/modules/trainees/trainee-get.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { TraineesService } from './trainees.service';
+
+@Controller()
+export class TraineeGetController {
+  constructor(private readonly svc: TraineesService) {}
+
+  @Get('trainee/get')
+  getToday() {
+    return this.svc.findToday();
+  }
+}

--- a/backend/src/modules/trainees/trainees.module.ts
+++ b/backend/src/modules/trainees/trainees.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { TraineesService } from './trainees.service';
 import { TraineesController } from './trainees.controller';
+import { TraineeGetController } from './trainee-get.controller';
 import { Trainee } from './entities/trainee.entity';
 import { TrainingProgram } from '../training-programs/entities/training-program.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Trainee, TrainingProgram])],
-  controllers: [TraineesController],
+  controllers: [TraineesController, TraineeGetController],
   providers: [TraineesService],
   exports: [TraineesService],
 })

--- a/backend/src/modules/trainees/trainees.service.ts
+++ b/backend/src/modules/trainees/trainees.service.ts
@@ -7,6 +7,7 @@ import { UpdateTraineeDto } from './dto/update-trainee.dto';
 import { AssignProgramDto } from './dto/assign-program.dto';
 import { TrainingProgram } from '../training-programs/entities/training-program.entity';
 import { ConfigService } from '@nestjs/config';
+import { Between } from 'typeorm';
 
 @Injectable()
 export class TraineesService {
@@ -26,6 +27,16 @@ export class TraineesService {
 
   findAll() {
     return this.repo.find();
+  }
+
+  findToday() {
+    const now = new Date();
+    const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+    return this.repo.find({
+      where: { reservedTime: Between(start, end) },
+      order: { reservedTime: 'ASC' },
+    });
   }
 
   findOne(id: number) {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import TraineeAttendance from '@components/layout/TraineeAttendance';
 import { faCalendar, faGear, faPlay, faTv } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useGetTraineesQuery } from '@store/slices/api/apiSlice';
 
@@ -9,6 +9,13 @@ export default function Home() {
     const navigate = useNavigate();
     const [currentTime, setCurrentTime] = useState('');
     const { data: trainees = [] } = useGetTraineesQuery();
+    const sortedTrainees = useMemo(
+        () =>
+            [...trainees].sort(
+                (a, b) => new Date(a.reservedTime).getTime() - new Date(b.reservedTime).getTime()
+            ),
+        [trainees]
+    );
 
     const userOptions = [
         {
@@ -74,7 +81,7 @@ export default function Home() {
                     <FontAwesomeIcon className="icon" icon={faCalendar} />
                     <span className="home__trainee_schedual-title-text">לוח האימונים להיום</span>
                 </h2>
-                {trainees.map((t) => (
+                {sortedTrainees.map((t) => (
                     <TraineeAttendance key={t.id} trainee={t} />
                 ))}
             </div>

--- a/frontend/src/store/slices/api/apiSlice.ts
+++ b/frontend/src/store/slices/api/apiSlice.ts
@@ -34,7 +34,7 @@ export const api = createApi({
             invalidatesTags: [{ type: 'Post', id: 'LIST' }],
         }),
         getTrainees: build.query<Trainee[], void>({
-            query: () => '/trainees',
+            query: () => '/trainee/get',
             providesTags: (result) =>
                 result
                     ? [


### PR DESCRIPTION
## Summary
- Provide a new `/trainee/get` backend route returning today's trainees ordered by upcoming time
- Switch frontend to use `/trainee/get` and sort trainees so soonest sessions appear first
- Remove Boostapp sync dependency from trainee screens

## Testing
- ✅ `npm test` (backend)
- ⚠️ `npm test` (frontend) *(Missing script: "test")*
- ⚠️ `npm run lint` (frontend) *(ProgramManagement.tsx: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68ae16daf2208332945e308b94c26303