### PR TITLE
refactor: store training times as bigint

### DIFF
--- a/backend/src/database/db-init.service.ts
+++ b/backend/src/database/db-init.service.ts
@@ -230,13 +230,13 @@ export class DbInitService implements OnModuleInit {
       CREATE TABLE training_times (
         id SERIAL PRIMARY KEY,
         user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
-        training_time TIMESTAMP NOT NULL,
+        training_time BIGINT NOT NULL,
         program_id INTEGER REFERENCES training_programs(id) ON DELETE SET NULL,
         details JSONB
       );
       CREATE INDEX idx_training_times_user ON training_times(user_id);
       INSERT INTO training_times (user_id, training_time, program_id, details)
-      VALUES (1, NOW(), 1, '{}');
+      VALUES (1, FLOOR(EXTRACT(EPOCH FROM NOW()) * 1000)::bigint, 1, '{}');
     `,
   };
 

--- a/backend/src/modules/training-times/dto/create-training-time.dto.ts
+++ b/backend/src/modules/training-times/dto/create-training-time.dto.ts
@@ -1,11 +1,11 @@
-import { IsInt, IsOptional, IsDateString, IsObject } from 'class-validator';
+import { IsInt, IsOptional, IsObject } from 'class-validator';
 
 export class CreateTrainingTimeDto {
   @IsInt()
   userId: number;
 
-  @IsDateString()
-  trainingTime: string;
+  @IsInt()
+  trainingTime: number;
 
   @IsInt()
   @IsOptional()

--- a/backend/src/modules/training-times/entities/training-time.entity.ts
+++ b/backend/src/modules/training-times/entities/training-time.entity.ts
@@ -10,8 +10,14 @@ export class TrainingTime {
   @ManyToOne(() => User, { eager: true, onDelete: 'CASCADE' })
   user: User;
 
-  @Column({ type: 'timestamp' })
-  training_time: Date;
+  @Column({
+    type: 'bigint',
+    transformer: {
+      to: (value: number) => value,
+      from: (value: string) => parseInt(value, 10),
+    },
+  })
+  training_time: number;
 
   @ManyToOne(() => TrainingProgram, { eager: true, nullable: true, onDelete: 'SET NULL' })
   program?: TrainingProgram | null;

--- a/backend/src/modules/training-times/training-times.service.ts
+++ b/backend/src/modules/training-times/training-times.service.ts
@@ -25,7 +25,7 @@ export class TrainingTimesService {
       }
       const entity = this.repo.create({
         user,
-        training_time: new Date(dto.trainingTime),
+        training_time: dto.trainingTime,
         program: program ?? undefined,
         details: dto.details,
       });


### PR DESCRIPTION
## Summary
- change training_times table to use BIGINT timestamps
- adjust TrainingTime entity and DTO for numeric values
- save epoch milliseconds directly when creating training times

## Testing
- `npm test`
- `npm run lint -- --no-fix` *(fails: 1588 errors, 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ae18ea23c483328969941e089454f8