### PR TITLE
Ensure trainee list loads when API URL is unset

### DIFF
--- a/frontend/src/pages/ProgramManagement.tsx
+++ b/frontend/src/pages/ProgramManagement.tsx
@@ -26,9 +26,10 @@ export default function ProgramManagement() {
         try {
             await deleteProgram(id);
             setPrograms((prev) => prev.filter((p) => p.id !== id));
-        } catch (err: any) {
+        } catch (err) {
             console.error(err);
-            setError(err.message || 'Failed to delete');
+            const message = err instanceof Error ? err.message : 'Failed to delete';
+            setError(message);
         }
     };
 

--- a/frontend/src/store/slices/api/apiSlice.ts
+++ b/frontend/src/store/slices/api/apiSlice.ts
@@ -8,7 +8,7 @@ import type { Exercise } from './Exercise';
 export const api = createApi({
     reducerPath: 'api',                         // unique key in the store
     baseQuery: fetchBaseQuery({
-        baseUrl: import.meta.env.VITE_API_URL,    // e.g. 'http://localhost:4000'
+        baseUrl: import.meta.env.VITE_API_URL || 'http://localhost:3001',    // default local API URL
         prepareHeaders(headers) {
             // if you have auth tokens:
             // const token = localStorage.getItem('token');


### PR DESCRIPTION
## Summary
- default `fetchBaseQuery` to `http://localhost:3001` when `VITE_API_URL` isn't set
- clean up `ProgramManagement` error handling to satisfy lint

## Testing
- `npm test` (backend)
- `npm run lint` (frontend)
- `npm test` (frontend) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae1aa9c30c83328f3b68168168644c