### PR TITLE
Fetch trainees on home load and align endpoint

### DIFF
--- a/backend/src/modules/trainees/trainee-get.controller.ts
+++ b/backend/src/modules/trainees/trainee-get.controller.ts
@@ -5,7 +5,7 @@ import { TraineesService } from './trainees.service';
 export class TraineeGetController {
   constructor(private readonly svc: TraineesService) {}
 
-  @Get('trainee/get')
+  @Get('trainees/get')
   getToday() {
     return this.svc.findToday();
   }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,12 +3,13 @@ import { faCalendar, faGear, faPlay, faTv } from '@fortawesome/free-solid-svg-ic
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useGetTraineesQuery } from '@store/slices/api/apiSlice';
+import axios from 'axios';
+import type { Trainee } from '@store/slices/api/Trainee';
 
 export default function Home() {
     const navigate = useNavigate();
     const [currentTime, setCurrentTime] = useState('');
-    const { data: trainees = [] } = useGetTraineesQuery();
+    const [trainees, setTrainees] = useState<Trainee[]>([]);
     const sortedTrainees = useMemo(
         () =>
             [...trainees].sort(
@@ -40,6 +41,11 @@ export default function Home() {
             iconColor: '#1d9e59',
         },
     ];
+
+    useEffect(() => {
+        const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+        axios.get<Trainee[]>(`${apiUrl}/trainees/get`).then((res) => setTrainees(res.data));
+    }, []);
 
     useEffect(() => {
         const updateClock = () => {

--- a/frontend/src/store/slices/api/apiSlice.ts
+++ b/frontend/src/store/slices/api/apiSlice.ts
@@ -34,7 +34,7 @@ export const api = createApi({
             invalidatesTags: [{ type: 'Post', id: 'LIST' }],
         }),
         getTrainees: build.query<Trainee[], void>({
-            query: () => '/trainee/get',
+            query: () => '/trainees/get',
             providesTags: (result) =>
                 result
                     ? [


### PR DESCRIPTION
## Summary
- Rename trainee endpoint to `/trainees/get` on server and API client
- Fetch trainees via axios when Home page mounts and render them

## Testing
- `npm test` (backend)
- `npm test` (frontend) *fails: Missing script "test"*
- `npm run lint` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68ae1cd10de48332b3f591d715fab202