### PR TITLE
Disable caching for trainee endpoint responses

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -17,9 +17,16 @@ async function bootstrap() {
 	if (!fs.existsSync(uploadPath)) {
 		fs.mkdirSync(uploadPath, { recursive: true });
 	}
-	const app = await NestFactory.create<NestExpressApplication>(AppModule);
+        const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
-	app.useGlobalFilters(new GlobalExceptionFilter());
+        // Disable HTTP caching so clients always receive a fresh response
+        app.set('etag', false);
+        app.use((_, res, next) => {
+                res.setHeader('Cache-Control', 'no-store');
+                next();
+        });
+
+        app.useGlobalFilters(new GlobalExceptionFilter());
 
 	app.useGlobalPipes(
 		new ValidationPipe({


### PR DESCRIPTION
## Summary
- disable HTTP caching in NestJS app to ensure trainee data is always returned

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe member access/assignment errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1f7ef4788332a4460af02a167a09