### PR TITLE
Disable caching for trainee endpoint responses

### DIFF
--- a/backend/src/database/db-init.service.ts
+++ b/backend/src/database/db-init.service.ts
@@ -236,7 +236,12 @@ export class DbInitService implements OnModuleInit {
       );
       CREATE INDEX idx_training_times_user ON training_times(user_id);
       INSERT INTO training_times (user_id, training_time, program_id, details)
-      VALUES (1, FLOOR(EXTRACT(EPOCH FROM NOW()) * 1000)::bigint, 1, '{}');
+      VALUES (
+        1,
+        FLOOR(EXTRACT(EPOCH FROM TIMESTAMP '2025-08-27 10:00:00') * 1000)::bigint,
+        1,
+        '{}'
+      );
     `,
   };
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -17,9 +17,16 @@ async function bootstrap() {
 	if (!fs.existsSync(uploadPath)) {
 		fs.mkdirSync(uploadPath, { recursive: true });
 	}
-	const app = await NestFactory.create<NestExpressApplication>(AppModule);
+        const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
-	app.useGlobalFilters(new GlobalExceptionFilter());
+        // Disable HTTP caching so clients always receive a fresh response
+        app.set('etag', false);
+        app.use((_, res, next) => {
+                res.setHeader('Cache-Control', 'no-store');
+                next();
+        });
+
+        app.useGlobalFilters(new GlobalExceptionFilter());
 
 	app.useGlobalPipes(
 		new ValidationPipe({


### PR DESCRIPTION
## Summary
- disable HTTP caching in NestJS app to ensure trainee data is always returned
- seed mock training time for user 1 and program 1 on 2025-08-27 10:00:00

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe member access/assignment errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1f7ef4788332a4460af02a167a09