### PR TITLE
Use human-readable session start times

### DIFF
--- a/backend/src/modules/sessions/dto/create-session.dto.ts
+++ b/backend/src/modules/sessions/dto/create-session.dto.ts
@@ -1,7 +1,8 @@
-import { IsArray, IsDateString, IsInt } from 'class-validator';
+import { IsArray, IsInt, IsString, Matches } from 'class-validator';
 
 export class CreateSessionDto {
-  @IsDateString()
+  @IsString()
+  @Matches(/^\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}$/)
   start_time: string;
 
   @IsArray()

--- a/backend/src/modules/sessions/entities/session.entity.ts
+++ b/backend/src/modules/sessions/entities/session.entity.ts
@@ -12,8 +12,8 @@ export class Session {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ type: 'timestamp' })
-  start_time: Date;
+  @Column({ type: 'varchar', length: 16 })
+  start_time: string;
 
   @ManyToMany(() => User, { eager: true })
   @JoinTable({

--- a/backend/src/modules/sessions/sessions.service.ts
+++ b/backend/src/modules/sessions/sessions.service.ts
@@ -18,7 +18,7 @@ export class SessionsService {
   async create(dto: CreateSessionDto) {
     const trainees = await this.users.findBy({ id: In(dto.trainee_ids) });
     const session = this.repo.create({
-      start_time: new Date(dto.start_time),
+      start_time: dto.start_time,
       trainees,
     });
     return this.repo.save(session);
@@ -35,7 +35,7 @@ export class SessionsService {
   async update(id: number, dto: UpdateSessionDto) {
     const session = await this.repo.findOneOrFail({ where: { id } });
     if (dto.start_time) {
-      session.start_time = new Date(dto.start_time);
+      session.start_time = dto.start_time;
     }
     if (dto.trainee_ids) {
       session.trainees = await this.users.findBy({ id: In(dto.trainee_ids) });


### PR DESCRIPTION
## Summary
- store session start_time as a string rather than a timestamp
- accept start_time in `dd/MM/yyyy HH:mm` format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae2941240c833293d434a674fba80b