### PR TITLE
feat: display all trainees for debugging

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -10,6 +10,7 @@ export default function Home() {
     const navigate = useNavigate();
     const [currentTime, setCurrentTime] = useState('');
     const [trainees, setTrainees] = useState<Trainee[]>([]);
+    const [debugTrainees, setDebugTrainees] = useState<Trainee[]>([]);
     const sortedTrainees = useMemo(
         () =>
             [...trainees].sort(
@@ -45,6 +46,7 @@ export default function Home() {
     useEffect(() => {
         const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
         axios.get<Trainee[]>(`${apiUrl}/trainees/get`).then((res) => setTrainees(res.data));
+        axios.get<Trainee[]>(`${apiUrl}/trainees`).then((res) => setDebugTrainees(res.data));
     }, []);
 
     useEffect(() => {
@@ -90,6 +92,17 @@ export default function Home() {
                 {sortedTrainees.map((t) => (
                     <TraineeAttendance key={t.id} trainee={t} />
                 ))}
+            </div>
+
+            <div className="home__debug container">
+                <h2>Debug: כל המתאמנים</h2>
+                <ul>
+                    {debugTrainees.map((t) => (
+                        <li key={t.id}>
+                            {t.name} - {new Date(t.reservedTime).toLocaleString('en-GB')}
+                        </li>
+                    ))}
+                </ul>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- show a debug list of all trainees on the home page
- fetch all trainees from the backend regardless of date

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae2cb0f87c83328b7fb3ef2839938d