### PR TITLE
feat: display all trainees for debugging

### DIFF
--- a/backend/src/modules/trainees/trainees.controller.ts
+++ b/backend/src/modules/trainees/trainees.controller.ts
@@ -22,13 +22,13 @@ export class TraineesController {
   }
 
   @Get()
-  findAll() {
-    return this.svc.findAll();
+  async findAll() {
+    return await this.svc.findAll();
   }
 
   @Get('get')
-  getToday() {
-    return this.svc.findToday();
+  async getToday() {
+    return await this.svc.findToday();
   }
 
   @Get(':id')

--- a/backend/src/modules/trainees/trainees.service.ts
+++ b/backend/src/modules/trainees/trainees.service.ts
@@ -25,15 +25,15 @@ export class TraineesService {
     });
   }
 
-  findAll() {
-    return this.repo.find();
+  async findAll() {
+    return await this.repo.find();
   }
 
-  findToday() {
+  async findToday() {
     const now = new Date();
     const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
     const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
-    return this.repo.find({
+    return await this.repo.find({
       where: { reservedTime: Between(start, end) },
       order: { reservedTime: 'ASC' },
     });

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -10,6 +10,7 @@ export default function Home() {
     const navigate = useNavigate();
     const [currentTime, setCurrentTime] = useState('');
     const [trainees, setTrainees] = useState<Trainee[]>([]);
+    const [debugTrainees, setDebugTrainees] = useState<Trainee[]>([]);
     const sortedTrainees = useMemo(
         () =>
             [...trainees].sort(
@@ -45,6 +46,7 @@ export default function Home() {
     useEffect(() => {
         const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
         axios.get<Trainee[]>(`${apiUrl}/trainees/get`).then((res) => setTrainees(res.data));
+        axios.get<Trainee[]>(`${apiUrl}/trainees`).then((res) => setDebugTrainees(res.data));
     }, []);
 
     useEffect(() => {
@@ -90,6 +92,17 @@ export default function Home() {
                 {sortedTrainees.map((t) => (
                     <TraineeAttendance key={t.id} trainee={t} />
                 ))}
+            </div>
+
+            <div className="home__debug container">
+                <h2>Debug: כל המתאמנים</h2>
+                <ul>
+                    {debugTrainees.map((t) => (
+                        <li key={t.id}>
+                            {t.name} - {new Date(t.reservedTime).toLocaleString('en-GB')}
+                        </li>
+                    ))}
+                </ul>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- show a debug list of all trainees on the home page
- fetch all trainees from the backend regardless of date
- ensure trainee queries are awaited to resolve results

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae2cb0f87c83328b7fb3ef2839938d