### PR TITLE
feat: persist training program assignments

### DIFF
--- a/frontend/src/components/TrainingProgramModal.tsx
+++ b/frontend/src/components/TrainingProgramModal.tsx
@@ -1,16 +1,20 @@
 import { useEffect, useState } from 'react';
 import SearchableSelect from './ui/SearchableSelect';
 import { getPrograms, type Program } from '../services/trainingPrograms';
+import type { Trainee } from '@store/slices/api/Trainee';
+import { useAssignProgramMutation } from '@store/slices/api/apiSlice';
 
 interface Props {
     isOpen: boolean;
     onClose: () => void;
+    trainee: Trainee;
 }
 
-export default function TrainingProgramModal({ isOpen, onClose }: Props) {
+export default function TrainingProgramModal({ isOpen, onClose, trainee }: Props) {
     const [programs, setPrograms] = useState<Program[]>([]);
     const [selection, setSelection] = useState('');
     const trainingOptions = ['כוח', 'קרדיו', 'גמישות'];
+    const [assignProgram] = useAssignProgramMutation();
 
     useEffect(() => {
         if (isOpen) {
@@ -19,6 +23,16 @@ export default function TrainingProgramModal({ isOpen, onClose }: Props) {
                 .catch((err) => console.error(err));
         }
     }, [isOpen]);
+
+    const handleSelect = async (program: Program) => {
+        if (!program.id) return;
+        try {
+            await assignProgram({ id: trainee.id, programId: program.id }).unwrap();
+            onClose();
+        } catch (err) {
+            console.error(err);
+        }
+    };
 
     if (!isOpen) return null;
 
@@ -43,7 +57,9 @@ export default function TrainingProgramModal({ isOpen, onClose }: Props) {
                     <li key={p.id} className="training-program-modal__item">
                         <span>{p.name}</span>
                         <div className="training-program-modal__item-actions">
-                            <button className="btn btn--success">בחר</button>
+                            <button className="btn btn--success" onClick={() => handleSelect(p)}>
+                                בחר
+                            </button>
                             <button className="btn btn--warning">העבר זמן</button>
                         </div>
                     </li>

--- a/frontend/src/components/layout/TraineeAttendance.tsx
+++ b/frontend/src/components/layout/TraineeAttendance.tsx
@@ -36,7 +36,11 @@ function TraineeAttendance({ trainee }: Props) {
             <button className="trainee-attendance__action" onClick={() => setOpen(true)}>
                 <span className="trainee-attendance__action-text">פתח מסך אימון</span>
             </button>
-            <TrainingProgramModal isOpen={open} onClose={() => setOpen(false)} />
+            <TrainingProgramModal
+                trainee={trainee}
+                isOpen={open}
+                onClose={() => setOpen(false)}
+            />
         </div>
     );
 }

--- a/frontend/src/pages/TraineeScreens.tsx
+++ b/frontend/src/pages/TraineeScreens.tsx
@@ -4,48 +4,10 @@ import type { Trainee } from '@store/slices/api/Trainee';
 import TrainingMonitorCube from '@components/layout/TrainingMonitorCube';
 import { useEffect, useMemo } from 'react';
 
-interface Exercise {
-    name: string;
-    sets: string;
-    weight: string;
-    rest: string;
-}
-
-interface LocalProgram {
-    id: number;
-    traineeName: string;
-    exercises: Exercise[];
-}
-
-const localPrograms: LocalProgram[] = [
-    {
-        id: 1,
-        traineeName: "ג'ון סמות",
-        exercises: [
-            { name: 'סקוואט', sets: '3', weight: '50kg', rest: '60s' },
-            { name: 'לחיצת חזה', sets: '3', weight: '40kg', rest: '60s' },
-            { name: 'חתירה', sets: '3', weight: '30kg', rest: '60s' },
-        ],
-    },
-    {
-        id: 2,
-        traineeName: 'דנה לוי',
-        exercises: [
-            { name: 'מכרעים', sets: '3', weight: '20kg', rest: '60s' },
-            { name: 'מתח', sets: '3', weight: 'משקל גוף', rest: '60s' },
-            { name: 'בטן', sets: '3', weight: '', rest: '60s' },
-        ],
-    },
-];
-
 export default function TraineeScreens() {
     const { data: trainees = [] } = useGetTraineesQuery();
     const [logTraining] = useLogTrainingMutation();
     const dispatch = useAppDispatch();
-
-    useEffect(() => {
-        localStorage.setItem('programs', JSON.stringify(localPrograms));
-    }, []);
 
     const sortedTrainees = useMemo(
         () =>
@@ -58,8 +20,6 @@ export default function TraineeScreens() {
     useEffect(() => {
         dispatch(setTrainees(sortedTrainees));
     }, [sortedTrainees, dispatch]);
-
-    const useLocal = (!sortedTrainees || sortedTrainees.length === 0) && localPrograms.length > 0;
 
     const completeTraining = (trainee: Trainee) => {
         if (!trainee.program) return;
@@ -84,34 +44,23 @@ export default function TraineeScreens() {
         <div className="trainee-screens container">
             <h1 className="trainee-screens__title">מוניטור אימונים</h1>
             <div className="trainee-screens__grid">
-                {useLocal &&
-                    localPrograms.map((program) => (
+                {sortedTrainees.map((t) => (
+                    <div key={t.id} className="trainee-card">
                         <TrainingMonitorCube
-                            key={program.id}
-                            traineeName={program.traineeName}
-                            programName=""
-                            exercises={program.exercises}
+                            traineeName={t.name}
+                            programName={t.program?.name}
+                            exercises={t.program?.exercises || []}
                         />
-                    ))}
-
-                {!useLocal &&
-                    sortedTrainees.map((t) => (
-                        <div key={t.id} className="trainee-card">
-                            <TrainingMonitorCube
-                                traineeName={t.name}
-                                programName={t.program?.name}
-                                exercises={t.program?.exercises || []}
-                            />
-                            {t.program && (
-                                <button
-                                    className="trainee-card__complete"
-                                    onClick={() => completeTraining(t)}
-                                >
-                                    סיים אימון
-                                </button>
-                            )}
-                        </div>
-                    ))}
+                        {t.program && (
+                            <button
+                                className="trainee-card__complete"
+                                onClick={() => completeTraining(t)}
+                            >
+                                סיים אימון
+                            </button>
+                        )}
+                    </div>
+                ))}
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- persist trainee training program selections by calling backend API instead of local storage
- show assigned training programs on trainee screens directly from database data

## Testing
- `npm run lint` (frontend)
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm test` (backend)
- `npm run lint` (backend) *(fails: 225 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ae39293af48332971ebcb5f115791d